### PR TITLE
Add cloudpathlib tests & fix GCV language detection

### DIFF
--- a/src/pdf_parser/pdf_utils/parsing_utils.py
+++ b/src/pdf_parser/pdf_utils/parsing_utils.py
@@ -836,11 +836,15 @@ class OCRProcessor:
             text = gcv_response.full_text_annotation.text
 
             # We assume one language per text block here which seems reasonable, but may not always be true.
-            language = (
-                gcv_response.full_text_annotation.pages[0]
-                .property.detected_languages[0]
-                .language_code
-            )
+            try:
+                language = (
+                    gcv_response.full_text_annotation.pages[0]
+                    .property.detected_languages[0]
+                    .language_code
+                )
+            except IndexError:
+                # No language was found in the GCV response
+                language = None
 
         # Save OCR result
         block_with_text = block.set(text=text)  # type: ignore


### PR DESCRIPTION
Two small changes here:
* added a test for use of the `--s3` flag in the CLI
* found and fixed an error where GCV didn't find a language (when words detected were individual letters), then the code was failing silently with an `IndexError`

The latter should fix the issues with not being able to find the pdf parser output that we were having in tests last week. I've raised [an issue](https://linear.app/climate-policy-radar/issue/DSCI-116/re-enable-logging-for-multiprocessing) to re-enable logging when running the PDF parser in `--parallel` mode too.