### PR TITLE
rename id, url and content_type fields

### DIFF
--- a/cli/parse_htmls.py
+++ b/cli/parse_htmls.py
@@ -31,8 +31,8 @@ def run_html_parser(input_tasks: List[ParserInput], output_dir: Union[Path, Clou
     for task in tqdm(input_tasks):
         # TODO: validate the language detection probability threshold
         parsed_html = html_parser.parse(task).detect_and_set_languages()
-        output_path = output_dir / f"{task.id}.json"
+        output_path = output_dir / f"{task.document_id}.json"
 
         output_path.write_text(parsed_html.json(indent=4, ensure_ascii=False))
 
-        logger.info(f"Output for {task.id} saved to {output_path}")
+        logger.info(f"Output for {task.document_id} saved to {output_path}")

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -36,18 +36,18 @@ def download_pdf(parser_input: ParserInput, output_dir: Union[Path, str]) -> Pat
     :return: path to PDF file in output_dir
     """
 
-    response = requests.get(parser_input.url)
+    response = requests.get(parser_input.document_url)
 
     if response.status_code != 200:
         # TODO: what exception should be raised here?
-        raise Exception(f"Could not get PDF from {parser_input.url}")
+        raise Exception(f"Could not get PDF from {parser_input.document_url}")
 
     if response.headers["Content-Type"] != "application/pdf":
         raise Exception(
-            f"Content-Type is for {parser_input.id} ({parser_input.url}) is not PDF: {response.headers['Content-Type']}"
+            f"Content-Type is for {parser_input.document_id} ({parser_input.document_url}) is not PDF: {response.headers['Content-Type']}"
         )
 
-    output_path = Path(output_dir) / f"{parser_input.id}.pdf"
+    output_path = Path(output_dir) / f"{parser_input.document_id}.pdf"
 
     with open(output_path, "wb") as f:
         f.write(response.content)
@@ -126,11 +126,11 @@ def parse_file(
         all_pages_metadata.append(page_metadata)
 
     document = ParserOutput(
-        id=input_task.id,
-        url=input_task.url,
+        document_id=input_task.document_id,
+        document_url=input_task.document_url,
         document_name=input_task.document_name,
         document_description=input_task.document_description,
-        content_type=input_task.content_type,
+        document_content_type=input_task.document_content_type,
         document_slug=input_task.document_slug,
         pdf_data=PDFData(
             page_metadata=all_pages_metadata,
@@ -139,7 +139,7 @@ def parse_file(
         ),
     ).set_document_languages_from_text_blocks(min_language_proportion=0.4)
 
-    output_path = output_dir / f"{input_task.id}.json"
+    output_path = output_dir / f"{input_task.document_id}.json"
 
     output_path.write_text(document.json(indent=4, ensure_ascii=False))
 

--- a/cli/run_parser.py
+++ b/cli/run_parser.py
@@ -105,7 +105,7 @@ def main(
     # We use `parse_raw(path.read_text())` instead of `parse_file(path)` because the latter tries to coerce CloudPath objects to pathlib.Path objects.
     document_ids_previously_parsed = set(
         [
-            ParserOutput.parse_raw(path.read_text()).id
+            ParserOutput.parse_raw(path.read_text()).document_id
             for path in output_dir_as_path.glob("*.json")
         ]
     )
@@ -117,17 +117,21 @@ def main(
 
     tasks = [ParserInput.parse_raw(path.read_text()) for path in files_to_parse]
     if not redo and document_ids_previously_parsed.intersection(
-        {task.id for task in tasks}
+        {task.document_id for task in tasks}
     ):
         logger.warning(
-            f"Found {len(document_ids_previously_parsed.intersection({task.id for task in tasks}))} documents that have already parsed. Skipping."
+            f"Found {len(document_ids_previously_parsed.intersection({task.document_id for task in tasks}))} documents that have already parsed. Skipping."
         )
         tasks = [
-            task for task in tasks if task.id not in document_ids_previously_parsed
+            task
+            for task in tasks
+            if task.document_id not in document_ids_previously_parsed
         ]
 
-    html_tasks = [task for task in tasks if task.content_type == "text/html"]
-    pdf_tasks = [task for task in tasks if task.content_type == "application/pdf"]
+    html_tasks = [task for task in tasks if task.document_content_type == "text/html"]
+    pdf_tasks = [
+        task for task in tasks if task.document_content_type == "application/pdf"
+    ]
 
     logger.info(f"Found {len(html_tasks)} HTML tasks and {len(pdf_tasks)} PDF tasks")
 

--- a/cli/test/test_data/input/test_html.json
+++ b/cli/test/test_data/input/test_html.json
@@ -1,8 +1,8 @@
 {
-    "id": "test_html",
-    "url": "https://www.gov.uk/feed-in-tariffs", 
+    "document_id": "test_html",
+    "document_url": "https://www.gov.uk/feed-in-tariffs", 
     "document_name": "test_html",
     "document_description": "test_html_description", 
-    "content_type": "text/html",
+    "document_content_type": "text/html",
     "document_slug": "YYY"
 }

--- a/cli/test/test_data/input/test_pdf.json
+++ b/cli/test/test_data/input/test_pdf.json
@@ -1,8 +1,8 @@
 {
-  "id": "test_pdf",
-  "url": "https://cdn.climatepolicyradar.org/MLI/2013/MLI-2013-07-06-Order+No.+2013-2374+_+MSIPC-SG+establishing+the+Steering+Committee+for+Disaster+Risk+Management+and+Adaptation+to+Climate+Change+Project_7a66d325b62dc6f18e6fbb18b51d5db9.pdf",
+  "document_id": "test_pdf",
+  "document_url": "https://cdn.climatepolicyradar.org/MLI/2013/MLI-2013-07-06-Order+No.+2013-2374+_+MSIPC-SG+establishing+the+Steering+Committee+for+Disaster+Risk+Management+and+Adaptation+to+Climate+Change+Project_7a66d325b62dc6f18e6fbb18b51d5db9.pdf",
   "document_name": "test_pdf",
   "document_description": "test_pdf_description",
-  "content_type": "application/pdf",
+  "document_content_type": "application/pdf",
   "document_slug": "XYX"
 }

--- a/cli/test/test_data/output/test_html.json
+++ b/cli/test/test_data/output/test_html.json
@@ -1,14 +1,14 @@
 {
-    "id": "test_html",
+    "document_id": "test_html",
     "document_name": "test_html",
     "document_description": "test_html_description",
-    "url": "https://www.industry.gov.au/funding-and-incentives/emissions-reduction-fund",
+    "document_url": "https://www.industry.gov.au/funding-and-incentives/emissions-reduction-fund",
     "languages": [
         "en"
     ],
     "translated": false,
     "document_slug": "YYY",
-    "content_type": "text/html",
+    "document_content_type": "text/html",
     "html_data": {
         "detected_title": "Machinery of Government (MoG) changes to our department from 1 July 2022",
         "detected_date": "2020-10-20",

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -61,11 +61,11 @@ def test_run_parser_skip_already_done(caplog) -> None:
             f.write(
                 ParserOutput.parse_obj(
                     {
-                        "id": "test_pdf",
-                        "url": "https://www.pdfs.org",
+                        "document_id": "test_pdf",
+                        "document_url": "https://www.pdfs.org",
                         "document_name": "test_pdf",
                         "document_description": "test_pdf_description",
-                        "content_type": "application/pdf",
+                        "document_content_type": "application/pdf",
                         "languages": ["en"],
                         "document_slug": "slug",
                         "pdf_data": {
@@ -81,11 +81,11 @@ def test_run_parser_skip_already_done(caplog) -> None:
             f.write(
                 ParserOutput.parse_obj(
                     {
-                        "id": "test_html",
-                        "url": "https://www.google.org",
+                        "document_id": "test_html",
+                        "document_url": "https://www.google.org",
                         "document_name": "test_html",
                         "document_description": "test_html_description",
-                        "content_type": "text/html",
+                        "document_content_type": "text/html",
                         "languages": ["en"],
                         "document_slug": "slug",
                         "html_data": {

--- a/src/html_parser/combined.py
+++ b/src/html_parser/combined.py
@@ -83,13 +83,15 @@ class CombinedParser(HTMLParser):
 
         try:
             requests_response = requests.get(
-                input.url,
+                input.document_url,
                 verify=False,
                 allow_redirects=True,
                 timeout=HTML_HTTP_REQUEST_TIMEOUT,
             )
         except Exception as e:
-            logger.error(f"Could not fetch {input.url} for {input.id}: {e}")
+            logger.error(
+                f"Could not fetch {input.document_url} for {input.document_id}: {e}"
+            )
             return self._get_empty_response(input)
 
         parsed_html = self.parse_html(requests_response.text, input)
@@ -99,18 +101,20 @@ class CombinedParser(HTMLParser):
             "<noscript>" in requests_response.text
         ):
             logger.info(
-                f"Falling back to JS-enabled browser for {input.id} ({input.url})"
+                f"Falling back to JS-enabled browser for {input.document_id} ({input.document_url})"
             )
             try:
                 with sync_playwright() as playwright:
                     html_playwright = self._get_html_with_js_enabled(
-                        playwright, input.url
+                        playwright, input.document_url
                     )
                     parsed_html_playwright = self.parse_html(html_playwright, input)
 
                 return parsed_html_playwright
             except Exception as e:
-                logger.error(f"Could not fetch {input.url} for {input.id}: {e}")
+                logger.error(
+                    f"Could not fetch {input.document_url} for {input.document_id}: {e}"
+                )
                 return self._get_empty_response(input)
 
         return parsed_html

--- a/src/html_parser/newsplease.py
+++ b/src/html_parser/newsplease.py
@@ -33,9 +33,13 @@ class NewsPleaseParser(HTMLParser):
         """
 
         try:
-            article = NewsPlease.from_html(html=html, url=input.url, fetch_images=False)
+            article = NewsPlease.from_html(
+                html=html, url=input.document_url, fetch_images=False
+            )
         except Exception as e:
-            logger.error(f"Failed to parse {input.url} for {input.id}: {e}")
+            logger.error(
+                f"Failed to parse {input.document_url} for {input.document_id}: {e}"
+            )
             return self._get_empty_response(input)
 
         return self._newsplease_article_to_parsed_html(article, input)
@@ -51,14 +55,16 @@ class NewsPleaseParser(HTMLParser):
 
         try:
             response = requests.get(
-                input.url,
+                input.document_url,
                 verify=False,
                 allow_redirects=True,
                 timeout=HTML_HTTP_REQUEST_TIMEOUT,
             )
 
         except Exception as e:
-            logger.error(f"Could not fetch {input.url} for {input.id}: {e}")
+            logger.error(
+                f"Could not fetch {input.document_url} for {input.document_id}: {e}"
+            )
             return self._get_empty_response(input)
 
         return self.parse_html(response.text, input)
@@ -94,11 +100,11 @@ class NewsPleaseParser(HTMLParser):
         ]
 
         return ParserOutput(
-            id=input.id,
-            url=input.url,
+            document_id=input.document_id,
+            document_url=input.document_url,
             document_name=input.document_name,
             document_description=input.document_description,
-            content_type=input.content_type,
+            document_content_type=input.document_content_type,
             document_slug=input.document_slug,
             html_data=HTMLData(
                 detected_title=newsplease_article.title,

--- a/src/html_parser/readability.py
+++ b/src/html_parser/readability.py
@@ -36,13 +36,15 @@ class ReadabilityParser(HTMLParser):
 
         try:
             response = requests.get(
-                input.url,
+                input.document_url,
                 verify=False,
                 allow_redirects=True,
                 timeout=HTML_HTTP_REQUEST_TIMEOUT,
             )
         except Exception as e:
-            logger.error(f"Could not fetch {input.url} for {input.id}: {e}")
+            logger.error(
+                f"Could not fetch {input.document_url} for {input.document_id}: {e}"
+            )
             return self._get_empty_response(input)
 
         if response.status_code != 200:
@@ -81,11 +83,11 @@ class ReadabilityParser(HTMLParser):
 
         # Readability doesn't provide a date
         return ParserOutput(
-            id=input.id,
-            content_type=input.content_type,
+            document_id=input.document_id,
+            document_content_type=input.document_content_type,
             document_name=input.document_name,
             document_description=input.document_description,
-            url=input.url,
+            document_url=input.document_url,
             document_slug=input.document_slug,
             html_data=HTMLData(
                 detected_title=title,

--- a/src/html_parser/test/test_parsers.py
+++ b/src/html_parser/test/test_parsers.py
@@ -27,11 +27,11 @@ def test_parse(url: str, parser: HTMLParser) -> None:
 
     input = ParserInput.parse_obj(
         {
-            "id": "test_id",
-            "url": url,
+            "document_id": "test_id",
+            "document_url": url,
             "document_name": "test_html",
             "document_description": "test_html_description",
-            "content_type": "text/html",
+            "document_content_type": "text/html",
             "document_slug": "YYY",
         }
     )

--- a/src/translator/test/test_translate.py
+++ b/src/translator/test/test_translate.py
@@ -62,7 +62,12 @@ def test_translate_parser_output() -> None:
     )
 
     # Check attributes that should not have changed
-    for attr in ("id", "url", "document_slug", "content_type"):
+    for attr in (
+        "document_id",
+        "document_url",
+        "document_slug",
+        "document_content_type",
+    ):
         assert getattr(translated_parser_output, attr) == getattr(parser_output, attr)
 
     for html_attr in ("detected_title", "detected_date", "has_valid_text"):


### PR DESCRIPTION
Added a `document_` prefix to all the above fields to match the field names in the search indexer. 

See [related PR in the search indexer](https://github.com/climatepolicyradar/navigator-search-indexer/pull/7).

@joel-wright I tried to make it so the pipeline isn't randomly renaming fields as it passes through the the task JSONs, which would mean that the loader should output fields with the names that opensearch (therefore the backend service) expects. Does that make sense to you?