### PR TITLE
adjustments to multiprocessing for pdfs

### DIFF
--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 import logging
-import multiprocessing
 import time
 import warnings
 from functools import partial
@@ -281,8 +280,9 @@ def run_pdf_parser(
         device=device,
     )
     if parallel:
-        cpu_count = multiprocessing.cpu_count() - 1
-        with concurrent.futures.ProcessPoolExecutor(max_workers=cpu_count) as executor:
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=config.PDF_N_PROCESSES
+        ) as executor:
             executor.map(file_parser, tqdm(input_tasks))
 
     else:

--- a/cli/run.sh
+++ b/cli/run.sh
@@ -1,3 +1,3 @@
 python -m pytest
-python -m cli.run_parser --s3 $s3_in $s3_out
+python -m cli.run_parser --s3 $s3_in $s3_out --parallel
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 import os
 from typing import List
+import multiprocessing
 
 HTML_MIN_NO_LINES_FOR_VALID_TEXT = int(
     os.getenv("HTML_MIN_NO_LINES_FOR_VALID_TEXT", "6")
@@ -20,5 +21,8 @@ PDF_OCR_AGENT = os.getenv("PDF_OCR_AGENT", "gcv")
 TEST_RUN = os.getenv("TEST_RUN", False)
 RUN_PDF_PARSER = os.getenv("RUN_PDF_PARSER", True)
 RUN_HTML_PARSER = os.getenv("RUN_HTML_PARSER", True)
+
+# Default set by trial and error based on behaviour of the parsing model
+PDF_N_PROCESSES = int(os.getenv("PDF_N_PROCESSES", multiprocessing.cpu_count() / 2))
 
 # TODO: http request headers?


### PR DESCRIPTION
As per this morning's chat i've changed the number of processes for pdf parsing to `multiprocessing.cpu_count()/2` and enabled the `--parallel` flag in the run script used on AWS.

This might break logging in the short term but we have [a task to fix it](https://linear.app/climate-policy-radar/issue/DSCI-116/re-enable-logging-for-multiprocessing) ASAP.