### PR TITLE
add --debug flag to s3 run

### DIFF
--- a/cli/run.sh
+++ b/cli/run.sh
@@ -1,3 +1,3 @@
 python -m pytest
-python -m cli.run_parser --s3 $s3_in $s3_out --parallel
+python -m cli.run_parser --s3 $s3_in $s3_out --parallel --debug
 


### PR DESCRIPTION
as per discussions today it'd be useful to save images of the bounding boxes predicted by the current pdf parser to plan next steps.

this PR adds the `--debug` flag to the bash command run when the parser is run on s3, which will save the images to a `/debug` folder in the configured s3 bucket