### PR TITLE
Debbugging cloudpath overwrite error and document_content-type key er…

### DIFF
--- a/cli/parse_htmls.py
+++ b/cli/parse_htmls.py
@@ -71,7 +71,10 @@ def run_html_parser(input_tasks: List[ParserInput], output_dir: Union[Path, Clou
 
         parsed_html = html_parser.parse(task).detect_and_set_languages()
 
-        output_path.write_text(parsed_html.json(indent=4, ensure_ascii=False))
+        try:
+            output_path.write_text(parsed_html.json(indent=4, ensure_ascii=False))
+        except cloudpathlib.exceptions.OverwriteNewerCloudError:
+            pass
 
         logger.info(f"Output for {task.document_id} saved to {output_path}")
 

--- a/cli/parse_htmls.py
+++ b/cli/parse_htmls.py
@@ -74,7 +74,8 @@ def run_html_parser(input_tasks: List[ParserInput], output_dir: Union[Path, Clou
         try:
             output_path.write_text(parsed_html.json(indent=4, ensure_ascii=False))
         except cloudpathlib.exceptions.OverwriteNewerCloudError:
-            pass
+            logger.info(f"Tried to write {task.document_id} to {output_path}, received OverwriteNewerCloudError and "
+                        f"therefore skipping.")
 
         logger.info(f"Output for {task.document_id} saved to {output_path}")
 

--- a/cli/parse_no_content_type.py
+++ b/cli/parse_no_content_type.py
@@ -41,6 +41,9 @@ def process_documents_with_no_content_type(
         )
 
         output_path = output_dir / f"{task.document_id}.json"
-        output_path.write_text(output.json(indent=4, ensure_ascii=False))
+        try:
+            output_path.write_text(output.json(indent=4, ensure_ascii=False))
+        except cloudpathlib.exceptions.OverwriteNewerCloudError:
+            pass
 
         logger.info(f"Output for {task.document_id} saved to {output_path}")

--- a/cli/parse_no_content_type.py
+++ b/cli/parse_no_content_type.py
@@ -44,6 +44,7 @@ def process_documents_with_no_content_type(
         try:
             output_path.write_text(output.json(indent=4, ensure_ascii=False))
         except cloudpathlib.exceptions.OverwriteNewerCloudError:
-            pass
+            logger.info(f"Tried to write {task.document_id} to {output_path}, received OverwriteNewerCloudError and "
+                        f"therefore skipping.")
 
         logger.info(f"Output for {task.document_id} saved to {output_path}")

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -316,7 +316,7 @@ def parse_file(
         try:
             output_path.write_text(document.json(indent=4, ensure_ascii=False))
         except cloudpathlib.exceptions.OverwriteNewerCloudError:
-            pass
+            logger.info(f"Tried to write to {output_path}, received OverwriteNewerCloudError and therefore skipping.")
 
         logging.info(f"Saved {output_path.name} to {output_dir}.")
 

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -313,7 +313,10 @@ def parse_file(
 
         output_path = output_dir / f"{input_task.document_id}.json"
 
-        output_path.write_text(document.json(indent=4, ensure_ascii=False))
+        try:
+            output_path.write_text(document.json(indent=4, ensure_ascii=False))
+        except cloudpathlib.exceptions.OverwriteNewerCloudError:
+            pass
 
         logging.info(f"Saved {output_path.name} to {output_dir}.")
 

--- a/cli/run_parser.py
+++ b/cli/run_parser.py
@@ -177,8 +177,7 @@ def main(
         else:
             try:
                 tasks.append(ParserInput.parse_raw(path.read_text()))  # type: ignore
-
-            except pydantic.error_wrappers.ValidationError as e:
+            except (pydantic.error_wrappers.ValidationError, KeyError) as e:
                 logger.error(
                     StandardErrorLog.parse_obj(
                         {

--- a/cli/translate_outputs.py
+++ b/cli/translate_outputs.py
@@ -64,6 +64,7 @@ def translate_parser_outputs(parser_output_dir: Union[Path, CloudPath]) -> None:
                     translated_parser_output.json(indent=4, ensure_ascii=False)
                 )
             except cloudpathlib.exceptions.OverwriteNewerCloudError:
-                pass
+                logger.info(
+                    f"Tried to write to {output_path}, received OverwriteNewerCloudError and therefore skipping.")
 
             logger.debug(f"Saved translated output to {output_path}.")

--- a/cli/translate_outputs.py
+++ b/cli/translate_outputs.py
@@ -59,7 +59,11 @@ def translate_parser_outputs(parser_output_dir: Union[Path, CloudPath]) -> None:
             )
             logger.debug(f"Translated {path} to {target_language}.")
 
-            output_path.write_text(
-                translated_parser_output.json(indent=4, ensure_ascii=False)
-            )
+            try:
+                output_path.write_text(
+                    translated_parser_output.json(indent=4, ensure_ascii=False)
+                )
+            except cloudpathlib.exceptions.OverwriteNewerCloudError:
+                pass
+
             logger.debug(f"Saved translated output to {output_path}.")


### PR DESCRIPTION
**OverwriteNewerCloudError** This exception is raised if we are asked to upload a file, but the one on the cloud is newer than our local version. This likely means that a separate process has updated the cloud version, and we don't want to overwrite and lose that new data in the cloud.

Therefore, if we see this error we wan't to just skip. Therefore, adding a try except with this error wherever we are uploading documents to s3. 

**KeyError** is throwing an exception when parsing input files. Therefore adding this to the try and except statement for parsing input files. This means we will see in the logs the exact files with the error. 

