### PR TITLE
Translation stage to only work on processed files. 

### DIFF
--- a/cli/run_parser.py
+++ b/cli/run_parser.py
@@ -218,7 +218,9 @@ def main(
     no_processing_tasks = []
     html_tasks = []
     pdf_tasks = []
+    output_tasks_paths = []
     for task in tasks:
+        output_tasks_paths.append(output_dir_as_path / f"{task.document_id}.json")
         if task.document_content_type == CONTENT_TYPE_HTML:
             html_tasks.append(task)
         elif task.document_content_type == CONTENT_TYPE_PDF:
@@ -252,7 +254,7 @@ def main(
             "Translating results to target languages specified in environment "
             f"variables: {','.join(TARGET_LANGUAGES)}"
         )
-        translate_parser_outputs(output_dir_as_path)
+        translate_parser_outputs(output_tasks_paths)
 
 
 if __name__ == "__main__":

--- a/cli/translate_outputs.py
+++ b/cli/translate_outputs.py
@@ -1,12 +1,14 @@
-from pathlib import Path
-from typing import Union, Set
+from typing import Set, Sequence
 import logging
 
-from cloudpathlib import CloudPath
+import logging
+from typing import Set, Sequence
+
+from cloudpathlib import S3Path
 from tqdm.auto import tqdm
 
-from src.config import TARGET_LANGUAGES, LOGGING_LEVEL
 from src.base import ParserOutput
+from src.config import TARGET_LANGUAGES, LOGGING_LEVEL
 from src.translator.translate import translate_parser_output
 
 logger = logging.getLogger(__name__)
@@ -40,15 +42,15 @@ def identify_translation_languages(document: ParserOutput, target_languages: Set
     return target_languages
 
 
-def translate_parser_outputs(parser_output_dir: Union[Path, CloudPath]) -> None:
+def translate_parser_outputs(task_output_paths: Sequence[str]) -> None:
     """
     Translate parser outputs saved in the output directory, and save the translated outputs to the output directory.
 
-    :param parser_output_dir: directory containing parser outputs
+    :param task_output_paths: A list of the paths to the parser outputs for this current instance to translate.
     """
     _target_languages = set(TARGET_LANGUAGES)
 
-    for path in tqdm(parser_output_dir.glob("*.json")):
+    for path in tqdm(task_output_paths):
         logger.debug(f"Translator processing - {path}.")
 
         parser_output = ParserOutput.parse_raw(path.read_text())

--- a/cli/translate_outputs.py
+++ b/cli/translate_outputs.py
@@ -53,8 +53,12 @@ def translate_parser_outputs(task_output_paths: Sequence[str]) -> None:
     for path in tqdm(task_output_paths):
         logger.debug(f"Translator processing - {path}.")
 
-        parser_output = ParserOutput.parse_raw(path.read_text())
-        logger.debug(f"Successfully parsed {path} from output dir during translation processing.")
+        try:
+            parser_output = ParserOutput.parse_raw(path.read_text())
+            logger.debug(f"Successfully parsed {path} from output dir during translation processing.")
+        except FileNotFoundError:
+            logger.error(f"Could not find {path} in output dir during translation processing.")
+            continue
 
         if should_be_translated(parser_output):
             logger.debug(f"Document should be translated: {path}")


### PR DESCRIPTION
Currently the translation stage of the parser is working on all of the files in the output directory. 
This is believed to be causing an OverwriteNewerCloudError as multiple parsers will run on the same file. 
Therefore, updating the parser translation stage to only work on the files that have been processed. 