### PR TITLE
Correcting typo in the logger call.

### DIFF
--- a/cli/run_parser.py
+++ b/cli/run_parser.py
@@ -73,7 +73,7 @@ def _get_files_to_parse(
     # If no file list is provided, run over all inputs in the input prefix
     env_files = []
     if FILES_TO_PARSE is not None:
-        logger.info(f"FILESTOPARSE: {FILES_TO_PARSE}")
+        _LOGGER.info(f"FILESTOPARSE: {FILES_TO_PARSE}")
         env_files = FILES_TO_PARSE.split("$")[1:]
 
     files_to_parse: list[str] = list(files or [])


### PR DESCRIPTION
The logger variable has the name _LOGGER but we call logger here and thus the following error is experienced in the latest pipeline integration test run. 


            
            
            Traceback (most recent call last):
            --
            File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
            return _run_code(code, main_globals, None,
            File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
            exec(code, run_globals)
            File "/app/cli/run_parser.py", line 257, in <module>
            main()
            File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
            return self.main(*args, **kwargs)
            File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1055, in main
            rv = self.invoke(ctx)
            File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
            return ctx.invoke(self.callback, **ctx.params)
            File "/usr/local/lib/python3.9/site-packages/click/core.py", line 760, in invoke
            return __callback(*args, **kwargs)
            File "/app/cli/run_parser.py", line 167, in main
            files_to_parse = _get_files_to_parse(files, input_dir_as_path)
            File "/app/cli/run_parser.py", line 76, in _get_files_to_parse
            logger.info(f"FILESTOPARSE: {FILES_TO_PARSE}")
            AttributeError: 'PlaceHolder' object has no attribute 'info'

