### PR TITLE
Feature/dont parse tables and figures text

### DIFF
--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -491,6 +491,15 @@ def parse_file(
                     },
                 )
 
+            # FIXME remove after testing
+            _LOGGER.info(
+                "postprocessed_layout",
+                extra={
+                    "props": {
+                        "postprocessed_layout": [b.type for b in postprocessed_layout]
+                    }
+                },
+            )
             ocr_blocks = Layout(
                 [b for b in postprocessed_layout if b.type in config.OCR_BLOCKS]
             )

--- a/src/config.py
+++ b/src/config.py
@@ -24,6 +24,8 @@ OCR_BLOCKS = [
     "Title",
     "Ambiguous",
     "Inferred from gaps",
+    "Table",
+    "Figure",
 ]
 
 # This is the number of pixels in the soft margin for a box to be considered nested within another box.

--- a/src/pdf_parser/pdf_utils/ocr.py
+++ b/src/pdf_parser/pdf_utils/ocr.py
@@ -14,7 +14,12 @@ from layoutparser.ocr import TesseractAgent, GCVAgent
 from shapely.geometry import Polygon
 import logging
 
-from src.base import PDFTextBlock, GoogleBlock, GoogleTextSegment, convert_coordinate_format
+from src.base import (
+    PDFTextBlock,
+    GoogleBlock,
+    GoogleTextSegment,
+    convert_coordinate_format,
+)
 from src.pdf_parser.pdf_utils.disambiguator.utils import lp_coords_to_shapely_polygon
 
 _LOGGER = logging.getLogger(__name__)
@@ -622,7 +627,7 @@ class OCRProcessor:
                 elif block.type in ["Table", "Figure"]:
                     text_blocks.append(
                         PDFTextBlock(
-                            text=[''],
+                            text=[""],
                             text_block_id=text_block_id,
                             coords=convert_coordinate_format(block),
                             type_confidence=block.score,


### PR DESCRIPTION
Pull request to identify the coordinates of the tables and figures but not parse text from them. Instead we use an empty string for the text as in the pydantic type for the TextBlock it is not optional. 

Example text block for a figure or table in the json output. 
```
{
                "text": [
                    ""
                ],
                "text_block_id": "p_37_b_8",
                "language": null,
                "type": "Figure",
                "type_confidence": 0.4169100821018219,
                "coords": [
                    [
                        59.62608337402344,
                        179.80508422851562
                    ],
                    [
                        547.4071655273438,
                        179.80508422851562
                    ],
                    [
                        547.4071655273438,
                        226.1058807373047
                    ],
                    [
                        59.62608337402344,
                        226.1058807373047
                    ]
                ],
                "page_number": 37
},
```