### PR TITLE
Feature/pre download model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,9 @@ COPY ./cli ./cli
 COPY ./.git ./.git
 COPY ./.pre-commit-config.yaml ./.flake8 ./.gitignore ./
 
+# Pre-download the model
+RUN python '/app/cli/warm_up_model.py'
+
+
 # Run the parser on the input s3 directory
 CMD [ "sh", "./cli/run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY ./.git ./.git
 COPY ./.pre-commit-config.yaml ./.flake8 ./.gitignore ./
 
 # Pre-download the model
+ENV PYTHONPATH "${PYTHONPATH}:/app"
 RUN python '/app/cli/warm_up_model.py'
 
 

--- a/cli/warm_up_model.py
+++ b/cli/warm_up_model.py
@@ -1,59 +1,13 @@
 """This module presents a method for downloading the model that is to be used in the parser so that it can be
 downloaded once and form a layer of the docker image rather than being downloaded at run time every time the
 parser is instantiated. """
-
-import logging
-from typing import Union
 import os
 
-from layoutparser.models import Detectron2LayoutModel
-from layoutparser.ocr import TesseractAgent, GCVAgent
+# Set cdn domain as the environment variable is required by the run_parser.py script
+os.environ["CDN_DOMAIN"] = "cdn.dummy.com"
 
-_LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
-
-PDF_OCR_AGENT = os.getenv("PDF_OCR_AGENT", "gcv")
-LAYOUTPARSER_MODEL = os.getenv("LAYOUTPARSER_MODEL", "mask_rcnn_X_101_32x8d_FPN_3x")
-
-
-def _get_detectron_model(model: str, device: str) -> Detectron2LayoutModel:
-    return Detectron2LayoutModel(
-        config_path=f"lp://PubLayNet/{model}",  # In model catalog,
-        label_map={0: "Text", 1: "Title", 2: "List", 3: "Table", 4: "Figure"},
-        device=device,
-    )
-
-
-def get_model(
-    model_name: str,
-    ocr_agent_name: str,
-    device: str,
-) -> tuple[Detectron2LayoutModel, Union[TesseractAgent, GCVAgent]]:
-    """Get the model for the parser."""
-    _LOGGER.info(
-        "Model Configuration",
-        extra={
-            "props": {
-                "model": model_name,
-                "ocr_agent": ocr_agent_name,
-                "device": device,
-            }
-        },
-    )
-    if ocr_agent_name == "gcv":
-        _LOGGER.warning(
-            "THIS IS COSTING MONEY/CREDITS!!!! - BE CAREFUL WHEN TESTING. SWITCH TO TESSERACT (FREE) FOR TESTING."
-        )
-
-    model = _get_detectron_model(model_name, device)
-    if ocr_agent_name == "tesseract":
-        ocr_agent = TesseractAgent()
-    elif ocr_agent_name == "gcv":
-        ocr_agent = GCVAgent()
-    else:
-        raise RuntimeError(f"Uknown OCR agent type: '{ocr_agent_name}'")
-
-    return model, ocr_agent
+from cli.parse_pdfs import get_model
+from src.config import LAYOUTPARSER_MODEL, PDF_OCR_AGENT
 
 
 if __name__ == "__main__":

--- a/cli/warm_up_model.py
+++ b/cli/warm_up_model.py
@@ -1,0 +1,64 @@
+"""This module presents a method for downloading the model that is to be used in the parser so that it can be
+downloaded once and form a layer of the docker image rather than being downloaded at run time every time the
+parser is instantiated. """
+
+import logging
+from typing import Union
+import os
+
+from layoutparser.models import Detectron2LayoutModel
+from layoutparser.ocr import TesseractAgent, GCVAgent
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
+
+PDF_OCR_AGENT = os.getenv("PDF_OCR_AGENT", "gcv")
+LAYOUTPARSER_MODEL = os.getenv("LAYOUTPARSER_MODEL", "mask_rcnn_X_101_32x8d_FPN_3x")
+
+
+def _get_detectron_model(model: str, device: str) -> Detectron2LayoutModel:
+    return Detectron2LayoutModel(
+        config_path=f"lp://PubLayNet/{model}",  # In model catalog,
+        label_map={0: "Text", 1: "Title", 2: "List", 3: "Table", 4: "Figure"},
+        device=device,
+    )
+
+
+def get_model(
+    model_name: str,
+    ocr_agent_name: str,
+    device: str,
+) -> tuple[Detectron2LayoutModel, Union[TesseractAgent, GCVAgent]]:
+    """Get the model for the parser."""
+    _LOGGER.info(
+        "Model Configuration",
+        extra={
+            "props": {
+                "model": model_name,
+                "ocr_agent": ocr_agent_name,
+                "device": device,
+            }
+        },
+    )
+    if ocr_agent_name == "gcv":
+        _LOGGER.warning(
+            "THIS IS COSTING MONEY/CREDITS!!!! - BE CAREFUL WHEN TESTING. SWITCH TO TESSERACT (FREE) FOR TESTING."
+        )
+
+    model = _get_detectron_model(model_name, device)
+    if ocr_agent_name == "tesseract":
+        ocr_agent = TesseractAgent()
+    elif ocr_agent_name == "gcv":
+        ocr_agent = GCVAgent()
+    else:
+        raise RuntimeError(f"Uknown OCR agent type: '{ocr_agent_name}'")
+
+    return model, ocr_agent
+
+
+if __name__ == "__main__":
+    get_model(
+        model_name=LAYOUTPARSER_MODEL,
+        ocr_agent_name=PDF_OCR_AGENT,
+        device="cpu",
+    )

--- a/cli/warm_up_model.py
+++ b/cli/warm_up_model.py
@@ -1,13 +1,16 @@
-"""This module presents a method for downloading the model that is to be used in the parser so that it can be
-downloaded once and form a layer of the docker image rather than being downloaded at run time every time the
-parser is instantiated. """
+"""Module presents a method for downloading the model that is to be used in the parser.
+
+This is so that it can be downloaded once and form a layer of the docker image rather than being downloaded at
+run time every time the parser is instantiated.
+"""
+
 import os
 
 # Set cdn domain as the environment variable is required by the run_parser.py script
 os.environ["CDN_DOMAIN"] = "cdn.dummy.com"
 
-from cli.parse_pdfs import get_model
-from src.config import LAYOUTPARSER_MODEL, PDF_OCR_AGENT
+from cli.parse_pdfs import get_model  # noqa: E402
+from src.config import LAYOUTPARSER_MODEL, PDF_OCR_AGENT  # noqa: E402
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Warm Up Model

Before running the ingest at scale this update could be beneficial for reducing run time and has been tech debt for a while.

We basically re-download the model to parser pdfs in the parser every time the parser image is instantiated which takes a bit of time.

Detailed in this linear ticket:
https://linear.app/climate-policy-radar/issue/SOF-17/store-model-in-parser

This parser PR and related https://github.com/climatepolicyradar/navigator-data-pipeline/pull/81 (to test it) detail updates to the parser to facilitate downloading this model at build time rather than at run time.

If the standard of the PR looks valid I propose getting this merged and tagged for the ingest.

Things to note:

Its the default model specified in config that would be downloaded
The size of the image will increase from 4409.47 [MB] to 5208.98 [MB] and thus the first pull of the image from ecr in prod into staging may take longer, builds also will take longer
Download time in the parser step takes roughly in aws 3 minutes per parser instantiation
Cloudwatch logs showing that the model is not downloaded when referencing the image:
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Fbatch$252Fjob/log-events/parser_job-0ca5356$252Fdefault$252F49d13fb0cf7d4d6f97edb412c3aa65c1