### PR TITLE
Update Dockerfile - pin python-3.9.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9.16
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
The timescale of the 3.9.17 official python image release matches our build failures & a previous attempted fix didn't work. Attempting to fall back to 3.9.16.