### PR TITLE
Feature/investigate additional document objects

### DIFF
--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -8,6 +8,7 @@ import warnings
 from functools import partial
 from pathlib import Path
 from typing import List, Optional, Union
+import hashlib
 
 import cloudpathlib.exceptions
 import requests
@@ -180,6 +181,14 @@ def download_pdf(
         return output_path
 
 
+def calculate_pdf_md5sum(file_path: str) -> str:
+    """Calculate the md5sum of a pdf file."""
+    with open(file_path, "rb") as file:
+        pdf_data = file.read()
+        md5_hash = hashlib.md5(pdf_data).hexdigest()
+    return md5_hash
+
+
 def parse_file(
     google_ai_client_: GoogleAIAPIWrapper,
     lp_obj: LayoutParserWrapper,
@@ -250,7 +259,9 @@ def parse_file(
             PDFPage
         ] = google_ai_client_.extract_document_text(str(pdf_path))
 
-        pdf_data: PDFData = assign_block_type(googled_parsed_document_pages, lp_obj)
+        pdf_data: PDFData = assign_block_type(
+            googled_parsed_document_pages, lp_obj, calculate_pdf_md5sum(str(pdf_path))
+        )
 
         _LOGGER.info(
             "Setting parser output for document.",

--- a/src/pdf_parser/combine.py
+++ b/src/pdf_parser/combine.py
@@ -45,7 +45,6 @@ def assign_block_type(
             page.extracted_content.pages[0].image.content, lp_obj
         )
 
-        # FIXME: We need to extract tables and figures as well, do we want to auto assign paragraphs as text?
         google_ai_layout_coords: list[
             GoogleTextBlockContent
         ] = get_google_ai_text_blocks(

--- a/src/pdf_parser/combine.py
+++ b/src/pdf_parser/combine.py
@@ -1,30 +1,18 @@
 from typing import List, Tuple
 
 import logging
-from google.cloud import documentai
 from layoutparser import Rectangle
 
 from src.base import PDFData, BlockType, PDFTextBlock, PDFPageMetadata
 from src.config import BLOCK_OVERLAP_THRESHOLD
-from src.pdf_parser.google_ai import get_google_ai_layout_coords, PDFPage
+from src.pdf_parser.google_ai import (
+    get_google_ai_text_blocks,
+    PDFPage,
+    GoogleTextBlockContent,
+)
 from src.pdf_parser.layout import LayoutParserWrapper, get_layout_parser_blocks
 
 _LOGGER = logging.getLogger(__file__)
-
-
-def layout_to_text(layout: documentai.Document.Page.Layout, text: str) -> list[str]:
-    """
-    Document AI identifies text in different parts of the document by their offsets in the entirety of the
-    document's text. This function converts offsets to a string.
-
-    If a text segment spans several lines, it will be stored in different text segments.
-    """
-    response = ""
-    for segment in layout.text_anchor.text_segments:
-        start_index = int(segment.start_index)
-        end_index = int(segment.end_index)
-        response += text[start_index:end_index]
-    return [response]
 
 
 def rectangle_to_coord(rectangle: Rectangle) -> List[Tuple[float, float]]:
@@ -56,17 +44,19 @@ def assign_block_type(
         layout_parser_blocks: list = get_layout_parser_blocks(
             page.extracted_content.pages[0].image.content, lp_obj
         )
-        google_ai_layout_coords: list[Rectangle] = get_google_ai_layout_coords(
-            page.extracted_content.pages[0]
+        google_ai_layout_coords: list[
+            GoogleTextBlockContent
+        ] = get_google_ai_text_blocks(
+            page=page.extracted_content.pages[0],
+            document_text=page.extracted_content.text,
         )
 
         for layout_block in layout_parser_blocks:
             for google_ai_block in google_ai_layout_coords:
-
                 block_type = BlockType.AMBIGUOUS
                 block_confidence = 0.0
                 if (
-                    layout_block.block.intersect(google_ai_block).area
+                    layout_block.block.intersect(google_ai_block.coordinates).area
                     / layout_block.block.area
                     > BLOCK_OVERLAP_THRESHOLD
                 ):
@@ -78,15 +68,12 @@ def assign_block_type(
 
                 document_text_blocks.append(
                     PDFTextBlock(
-                        coords=rectangle_to_coord(google_ai_block),
+                        coords=rectangle_to_coord(google_ai_block.coordinates),
                         page_number=page.page_number,
-                        text_block_id=len(document_text_blocks) + 1,
+                        text_block_id=int(len(document_text_blocks)) + 1,
                         type=block_type,
                         type_confidence=block_confidence,
-                        text=layout_to_text(
-                            page.extracted_content.pages[0].layout,
-                            page.extracted_content.text,
-                        ),
+                        text=[google_ai_block.text],
                         language=page.extracted_content.pages[0]
                         .detected_languages[0]
                         .language_code,

--- a/src/pdf_parser/combine.py
+++ b/src/pdf_parser/combine.py
@@ -25,7 +25,9 @@ def rectangle_to_coord(rectangle: Rectangle) -> List[Tuple[float, float]]:
 
 
 def assign_block_type(
-    parsed_document_pages: list[PDFPage], lp_obj: LayoutParserWrapper
+    parsed_document_pages: list[PDFPage],
+    lp_obj: LayoutParserWrapper,
+    document_md5sum: str,
 ) -> PDFData:
     """The google document ai api has many good features, however it does not support text block type detection.
 
@@ -37,13 +39,13 @@ def assign_block_type(
     """
     document_text_blocks = []
     document_pages_metadata = []
-    # FIXME: Generate this for the document
-    document_md5sum = "1123123"  # document.md5_checksum
 
     for page in parsed_document_pages:
         layout_parser_blocks: list = get_layout_parser_blocks(
             page.extracted_content.pages[0].image.content, lp_obj
         )
+
+        # FIXME: We need to extract tables and figures as well, do we want to auto assign paragraphs as text?
         google_ai_layout_coords: list[
             GoogleTextBlockContent
         ] = get_google_ai_text_blocks(

--- a/src/pdf_parser/google_ai.py
+++ b/src/pdf_parser/google_ai.py
@@ -1,5 +1,5 @@
 import io
-from typing import Any, Optional
+from typing import Any
 
 from PyPDF2 import PdfReader, PdfWriter
 from google.api_core.client_options import ClientOptions

--- a/src/pdf_parser/google_ai.py
+++ b/src/pdf_parser/google_ai.py
@@ -94,13 +94,13 @@ def get_google_ai_text_blocks(
     for paragraph in page.paragraphs:
         text = layout_to_text(layout=paragraph.layout, text=document_text)
 
-        blocks = paragraph.layout.bounding_poly.normalized_vertices
+        box_vertices = paragraph.layout.bounding_poly.normalized_vertices
 
         rectangle_scaled = Rectangle(
-            x_1=blocks[0].x * page_vertices.x,
-            y_1=blocks[0].y * page_vertices.y,
-            x_2=blocks[2].x * page_vertices.x,
-            y_2=blocks[2].y * page_vertices.y,
+            x_1=box_vertices[0].x * page_vertices.x,
+            y_1=box_vertices[0].y * page_vertices.y,
+            x_2=box_vertices[2].x * page_vertices.x,
+            y_2=box_vertices[2].y * page_vertices.y,
         )
 
         page_block_content.append(

--- a/src/pdf_parser/google_ai.py
+++ b/src/pdf_parser/google_ai.py
@@ -7,6 +7,15 @@ from google.cloud import documentai  # type: ignore
 from google.cloud import documentai_v1
 from layoutparser.elements import Rectangle
 from pydantic import BaseModel
+from enum import Enum
+
+
+class GoogleTypes(str, Enum):
+    """Enum for Google AI block types."""
+
+    VISUAL_ELEMENT = "VISUAL_ELEMENT"
+    PARAGRAPH = "PARAGRAPH"
+    TABLE = "TABLE"
 
 
 class PDFPage(BaseModel):
@@ -21,9 +30,8 @@ class GoogleTextBlockContent(BaseModel):
 
     text: str
     coordinates: Any
-    # TODO add Enum for type
     # TODO we aren't currently using or persisting this information, should we?
-    google_type: str
+    google_type: GoogleTypes
 
 
 class GoogleAIAPIWrapper:
@@ -122,7 +130,7 @@ def get_google_ai_text_blocks(
                 coordinates=layout_to_scaled_rectangle(
                     normalized_vertices=box_vertices, page_vertices=page_vertices
                 ),
-                google_type="paragraph",
+                google_type=GoogleTypes.PARAGRAPH,
             )
         )
 
@@ -137,7 +145,7 @@ def get_google_ai_text_blocks(
                 coordinates=layout_to_scaled_rectangle(
                     normalized_vertices=box_vertices, page_vertices=page_vertices
                 ),
-                google_type="table",
+                google_type=GoogleTypes.TABLE,
             )
         )
 
@@ -152,7 +160,7 @@ def get_google_ai_text_blocks(
                 coordinates=layout_to_scaled_rectangle(
                     normalized_vertices=box_vertices, page_vertices=page_vertices
                 ),
-                google_type="visual_element",
+                google_type=GoogleTypes.VISUAL_ELEMENT,
             )
         )
 

--- a/src/pdf_parser/layout.py
+++ b/src/pdf_parser/layout.py
@@ -1,11 +1,9 @@
-import os
 from io import BytesIO
 
-import layoutparser as lp
 import cv2
+import layoutparser as lp
 import numpy as np
 from PIL import Image
-from layoutparser.elements import Rectangle
 from layoutparser.elements.layout import Layout
 
 from src.config import LAYOUTPARSER_BOX_DETECTION_THRESHOLD


### PR DESCRIPTION
### PR Includes

- Using paragraphs, tables and visual elements rather than layout to retrieve text 
- Refactoring 
- Getting the md5sum 

Decisions: 
- Do we want to use the google types of paragraph [title,text] to assist with block type assignment.
- We extracted zero tables or visual elements from the test documents so this functionality appears to be pretty pointless. 


### Results Analysis: 

**Text Amount** 

Left is the results from using the paragraphs to get text. 
Right is using the layout to get the text. 

We can clearly see that we returned an order of magnitude less text when using the paragraphs to get the text from the document. 

I'm assuming that there must be duplication when using the layout to get the text (INVESTIGATE)! 

Upon reviewing the code for the other branch I believe the following may have caused the huge document count:
![image](https://github.com/climatepolicyradar/navigator-document-parser/assets/58440325/9f53e181-9a7a-4f26-8c9c-6687be259a89)

This appears to be getting text from the entire page for every text block. Upon reviewing the output we can infact see duplicate data.

![image](https://github.com/climatepolicyradar/navigator-document-parser/assets/58440325/33f2bc43-358d-4e81-89f8-8c6d8173bbf6)


**Text Block Profile**

As expected using paragraphs not larger blocks we have more, shorter text blocks. 

**Text Block Assignment**

For the first document in the results:
13.3% of text blocks assigned a type for the paragraphs option. 
15.4% of text blocks assigned a type for the layout option. 


<img width="1046" alt="image" src="https://github.com/climatepolicyradar/navigator-document-parser/assets/58440325/187bb249-b05c-494c-a248-ea714b818960">
