### PR TITLE
Integrate scrapeops 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ PDF_OCR_AGENT=tesseract
 
 # Files to parse by flag e.g. 1331.0.json
 #FILES_TO_PARSE_FLAG=
+
+# Scrape Ops is used to provide a proxy for scraping html pages
+#SCRAPEOPS_API_KEY=

--- a/src/config.py
+++ b/src/config.py
@@ -28,16 +28,17 @@ OCR_BLOCKS = [
     "Figure",
 ]
 
-# This is the number of pixels in the soft margin for a box to be considered nested within another box.
-# In particular, we inflate the potential container box by this amount in each direction, and then
-# check if the potential contained box is fully contained within the inflated container box.
+# This is the number of pixels in the soft margin for a box to be considered nested
+# within another box. In particular, we inflate the potential container box by this
+# amount in each direction, and then check if the potential contained box is fully
+# contained within the inflated container box.
 LAYOUTPARSER_UNNEST_SOFT_MARGIN = int(
     os.getenv("LAYOUTPARSER_UNNEST_SOFT_MARGIN", "15")
 )
-# We want to avoid box overlaps to avoid OCR capturing cut-off text or capturing text twice.
-# This is the minimum number of pixel overlaps before reducing size to avoid OCR conflicts. The
-# idea is that a small overlap is probably just whitespace, but a large overlap is probably
-# text that is being captured twice.
+# We want to avoid box overlaps to avoid OCR capturing cut-off text or capturing text
+# twice. This is the minimum number of pixel overlaps before reducing size to avoid
+# OCR conflicts. The idea is that a small overlap is probably just whitespace,
+# but a large overlap is probably text that is being captured twice.
 LAYOUTPARSER_MIN_OVERLAPPING_PIXELS_HORIZONTAL = int(
     os.getenv("LAYOUTPARSER_MIN_OVERLAPPING_PIXELS_HORIZONTAL", "5")
 )
@@ -55,9 +56,10 @@ LAYOUTPARSER_TOP_EXCLUDE_THRESHOLD = float(
 LAYOUTPARSER_BOTTOM_EXCLUDE_THRESHOLD = float(
     os.getenv("LAYOUTPARSER_BOTTOM_EXCLUDE_THRESHOLD", "0.1")
 )
-# Threshold for replacing blocks from google with blocks from the model. e.g.
-# if a block from layoutparser is 95% covered by a block from google, as measured by intersection over
-# union, then the block from layoutparser will be replaced by the block from google.
+# Threshold for replacing blocks from google with blocks from the model. e.g. if a
+# block from layoutparser is 95% covered by a block from google, as measured by
+# intersection over union, then the block from layoutparser will be replaced by the
+# block from google.
 LAYOUTPARSER_REPLACE_THRESHOLD = float(
     os.getenv("LAYOUTPARSER_REPLACE_THRESHOLD", "0.9")
 )
@@ -78,3 +80,5 @@ RUN_TRANSLATION = os.getenv("RUN_TRANSLATION", "true").lower() == "true"
 PDF_N_PROCESSES = int(os.getenv("PDF_N_PROCESSES", multiprocessing.cpu_count() / 2))
 FILES_TO_PARSE = os.getenv("files_to_parse")
 LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "DEBUG").upper()
+# Scrape Ops is used to provide a proxy for scraping html pages
+SCRAPEOPS_API_KEY = os.getenv("SCRAPEOPS_API_KEY")

--- a/src/html_parser/combined.py
+++ b/src/html_parser/combined.py
@@ -92,7 +92,7 @@ class CombinedParser(HTMLParser):
         try:
             if input.document_source_url is None:
                 raise ValueError(
-                    f"HTML processing was supplied an empty source URL for {input.document_id} "
+                    f"HTML processing was supplied an empty source URL for {input.document_id}"
                 )
             proxy_url = get_proxy_url(input.document_source_url)
             _LOGGER.info(

--- a/src/html_parser/combined.py
+++ b/src/html_parser/combined.py
@@ -12,6 +12,7 @@ from src.config import (
     HTML_HTTP_REQUEST_TIMEOUT,
     HTML_MAX_PARAGRAPH_LENGTH_WORDS,
 )
+from src.utils import get_proxy_url
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/html_parser/combined.py
+++ b/src/html_parser/combined.py
@@ -92,11 +92,17 @@ class CombinedParser(HTMLParser):
         try:
             if input.document_source_url is None:
                 raise ValueError(
-                    f"HTML processing was supplied an empty source URL for {input.document_id}"
+                    f"HTML processing was supplied an empty source URL for {input.document_id} "
                 )
-
+            proxy_url = get_proxy_url(input.document_source_url)
+            _LOGGER.info(
+                "Using proxy url from srapeops.",
+                extra={
+                    "props": {"proxy_url": proxy_url}
+                }
+            )
             requests_response = requests.get(
-                input.document_source_url,
+                proxy_url,
                 verify=False,
                 allow_redirects=True,
                 timeout=HTML_HTTP_REQUEST_TIMEOUT,

--- a/src/html_parser/combined.py
+++ b/src/html_parser/combined.py
@@ -98,9 +98,7 @@ class CombinedParser(HTMLParser):
             proxy_url = get_proxy_url(input.document_source_url)
             _LOGGER.info(
                 "Using proxy url from srapeops.",
-                extra={
-                    "props": {"proxy_url": proxy_url}
-                }
+                extra={"props": {"proxy_url": proxy_url}},
             )
             requests_response = requests.get(
                 proxy_url,

--- a/src/html_parser/combined.py
+++ b/src/html_parser/combined.py
@@ -98,24 +98,20 @@ class CombinedParser(HTMLParser):
                 )
 
             if SCRAPEOPS_API_KEY:
-                proxy_url = get_proxy_url(input.document_source_url)
+                request_url = get_proxy_url(input.document_source_url)
                 _LOGGER.info(
                     "Using proxy url from srapeops.",
-                    extra={"props": {"proxy_url": proxy_url}},
-                )
-                requests_response = requests.get(
-                    proxy_url,
-                    verify=False,
-                    allow_redirects=True,
-                    timeout=HTML_HTTP_REQUEST_TIMEOUT,
+                    extra={"props": {"proxy_url": request_url}},
                 )
             else:
-                requests_response = requests.get(
-                    input.document_source_url,
-                    verify=False,
-                    allow_redirects=True,
-                    timeout=HTML_HTTP_REQUEST_TIMEOUT,
-                )
+                request_url = input.document_source_url
+
+            requests_response = requests.get(
+                request_url,
+                verify=False,
+                allow_redirects=True,
+                timeout=HTML_HTTP_REQUEST_TIMEOUT,
+            )
         except Exception as e:
             _LOGGER.error(
                 "Failed to download html document.",

--- a/src/html_parser/combined.py
+++ b/src/html_parser/combined.py
@@ -11,6 +11,7 @@ from src.config import (
     HTML_MIN_NO_LINES_FOR_VALID_TEXT,
     HTML_HTTP_REQUEST_TIMEOUT,
     HTML_MAX_PARAGRAPH_LENGTH_WORDS,
+    SCRAPEOPS_API_KEY,
 )
 from src.utils import get_proxy_url
 
@@ -95,17 +96,26 @@ class CombinedParser(HTMLParser):
                 raise ValueError(
                     f"HTML processing was supplied an empty source URL for {input.document_id}"
                 )
-            proxy_url = get_proxy_url(input.document_source_url)
-            _LOGGER.info(
-                "Using proxy url from srapeops.",
-                extra={"props": {"proxy_url": proxy_url}},
-            )
-            requests_response = requests.get(
-                proxy_url,
-                verify=False,
-                allow_redirects=True,
-                timeout=HTML_HTTP_REQUEST_TIMEOUT,
-            )
+
+            if SCRAPEOPS_API_KEY:
+                proxy_url = get_proxy_url(input.document_source_url)
+                _LOGGER.info(
+                    "Using proxy url from srapeops.",
+                    extra={"props": {"proxy_url": proxy_url}},
+                )
+                requests_response = requests.get(
+                    proxy_url,
+                    verify=False,
+                    allow_redirects=True,
+                    timeout=HTML_HTTP_REQUEST_TIMEOUT,
+                )
+            else:
+                requests_response = requests.get(
+                    input.document_source_url,
+                    verify=False,
+                    allow_redirects=True,
+                    timeout=HTML_HTTP_REQUEST_TIMEOUT,
+                )
         except Exception as e:
             _LOGGER.error(
                 "Failed to download html document.",

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from src.config import SCRAPEOPS_API_KEY
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,15 @@
+from src.config import SCRAPEOPS_API_KEY
+
+
+def get_proxy_url(url: str) -> str:
+    """Get a ScrapeOps proxy URL for the given URL."""
+
+    if not SCRAPEOPS_API_KEY:
+        raise ValueError(
+            "SCRAPEOPS_API_KEY must be set in environment variables to use a scrapeops "
+            "proxy. "
+        )
+
+    payload = {"api_key": SCRAPEOPS_API_KEY, "url": url}
+
+    return "https://proxy.scrapeops.io/v1/?" + urlencode(payload)


### PR DESCRIPTION
### Integrate Scrapeops

During ascor ingest some html documents failed to download from source in the parser. These did succeed in being downloaded from source during websraping to identify the content type when using scrapeops. Thus, this pr integrates this functionality in the parser to facilitate successful download. 

We will then rerun the failed documents with the image built from this branch. 

[Linear Ticket](https://linear.app/climate-policy-radar/issue/RND-192/parse-ascor-documents)