### PR TITLE
Fix tests 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,14 +4,13 @@
 
 # OPTIONAL ENV VARS - DEFAULTS SET IN src/config.py
 HTML_MIN_NO_LINES_FOR_VALID_TEXT=6
-HTML_HTTP_REQUEST_TIMEOUT=30  # seconds
-HTML_MAX_PARAGRAPH_LENGTH_WORDS=500 # maximum number of words in the longest paragraph in a page before falling back to second-option parser
-TARGET_LANGUAGES=en # comma-separated 2-letter ISO codes
-LAYOUTPARSER_MODEL_THRESHOLD_RESTRICTIVE=0.5
-
-# Recommended env for local testing - small model and local OCR
-LAYOUTPARSER_MODEL=faster_rcnn_R_50_FPN_3x
-PDF_OCR_AGENT=tesseract
+# Timeout in seconds
+HTML_HTTP_REQUEST_TIMEOUT=30
+# maximum number of words in the longest paragraph in a page before falling back to
+#  the second-option parser
+HTML_MAX_PARAGRAPH_LENGTH_WORDS=500
+# comma-separated 2-letter ISO codes
+TARGET_LANGUAGES=en
 
 # Default CDN Domain
 #CDN_DOMAIN=
@@ -31,3 +30,8 @@ PDF_OCR_AGENT=tesseract
 
 # Files to parse by flag e.g. 1331.0.json
 #FILES_TO_PARSE_FLAG=
+
+
+# Azure Processor Credentials
+#AZURE_PROCESSOR_KEY=
+#AZURE_PROCESSOR_ENDPOINT=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Run Unit Tests
         run:  make test
+        with:
+          AZURE_PROCESSOR_KEY: ${{ secrets.AZURE_PROCESSOR_KEY }}
+          AZURE_PROCESSOR_ENDPOINT: ${{ secrets.AZURE_PROCESSOR_ENDPOINT }}
 
       - name: Run Integration Tests
         run: echo TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ pre-commit-checks-all-files:
 
 test:
 	docker build -t navigator-document-parser .
-	docker run -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e "CDN_DOMAIN=cdn.climatepolicyradar.org" --network host navigator-document-parser python -m pytest -vvv
+	docker run -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e "CDN_DOMAIN=cdn.dev.climatepolicyradar.org" --network host navigator-document-parser python -m pytest -vvv
 
 run_docker:
 	docker build -t html-parser .

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ install:
 	pip3 install --no-cache -r requirements.txt
 
 run_local:
-	LAYOUTPARSER_MODEL=faster_rcnn_R_50_FPN_3x PDF_OCR_AGENT=tesseract TARGET_LANGUAGES=en CDN_DOMAIN=cdn.climatepolicyradar.org GOOGLE_APPLICATION_CREDENTIALS=./credentials/google-creds.json python -m cli.run_parser ./data/raw ./data/processed
+	TARGET_LANGUAGES=en CDN_DOMAIN=cdn.climatepolicyradar.org GOOGLE_APPLICATION_CREDENTIALS=./credentials/google-creds.json python -m cli.run_parser ./data/raw ./data/processed
 
 test_local:
-	LAYOUTPARSER_MODEL=faster_rcnn_R_50_FPN_3x PDF_OCR_AGENT=tesseract TARGET_LANGUAGES=en CDN_DOMAIN=cdn.climatepolicyradar.org python -m pytest -vvv
+	TARGET_LANGUAGES=en CDN_DOMAIN=cdn.climatepolicyradar.org python -m pytest -vvv
 
 build:
 	docker build -t navigator-document-parser .
@@ -20,7 +20,7 @@ pre-commit-checks-all-files:
 
 test:
 	docker build -t navigator-document-parser .
-	docker run -e "LAYOUTPARSER_MODEL=faster_rcnn_R_50_FPN_3x" -e "PDF_OCR_AGENT=tesseract" -e "CDN_DOMAIN=cdn.climatepolicyradar.org" --network host navigator-document-parser python -m pytest -vvv
+	docker run -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e "CDN_DOMAIN=cdn.climatepolicyradar.org" --network host navigator-document-parser python -m pytest -vvv
 
 run_docker:
 	docker build -t html-parser .

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -196,8 +196,8 @@ def read_local_json_to_bytes(path_: str) -> bytes:
 
 
 def parse_file(
-    azure_client: AzureApiWrapper,
     input_task: ParserInput,
+    azure_client: AzureApiWrapper,
     output_dir: Union[Path, S3Path],
     redo: bool = False,
 ):
@@ -357,9 +357,9 @@ def run_pdf_parser(
 
     file_parser = partial(
         parse_file,
+        azure_client=azure_client,
         output_dir=output_dir,
         redo=redo,
-        azure_client=azure_client,
     )
     if parallel:
         cpu_count = min(3, multiprocessing.cpu_count() - 1)

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -267,11 +267,23 @@ def parse_file(
             )
         except ServiceRequestError as e:
             _LOGGER.exception(
-                "Failed to parse document with Azure API. No connection adapters were "
-                "found for for the endpoint in use.",
+                "Failed to parse document with Azure API. This is most likely due to "
+                "incorrect azure api credentials.",
                 extra={
                     "props": {
                         "document_id": input_task.document_id,
+                        "error_message": str(e.message),
+                    }
+                },
+            )
+            return None
+        except Exception as e:
+            _LOGGER.exception(
+                "Failed to parse document with Azure API.",
+                extra={
+                    "props": {
+                        "document_id": input_task.document_id,
+                        "error_message": str(e),
                     }
                 },
             )

--- a/cli/test/test_data/input/test_pdf.json
+++ b/cli/test/test_data/input/test_pdf.json
@@ -2,7 +2,7 @@
   "document_id": "test_pdf",
   "document_metadata": {},
   "document_source_url": "https://example.com/MLI/2013/MLI-2013-07-06-Order+No.+2013-2374+_+MSIPC-SG+establishing+the+Steering+Committee+for+Disaster+Risk+Management+and+Adaptation+to+Climate+Change+Project_7a66d325b62dc6f18e6fbb18b51d5db9.pdf",
-  "document_cdn_object": "MLI/2013/MLI-2013-07-06-Order+No.+2013-2374+_+MSIPC-SG+establishing+the+Steering+Committee+for+Disaster+Risk+Management+and+Adaptation+to+Climate+Change+Project_7a66d325b62dc6f18e6fbb18b51d5db9.pdf",
+  "document_cdn_object": "MLI/2013/order-no-2013-2374-msipc-sg-establishing-the-steering-committee-for-disaster-risk-management-and-adaptation-to-climate-change-project_7a66d325b62dc6f18e6fbb18b51d5db9.pdf",
   "document_md5_sum": "7a66d325b62dc6f18e6fbb18b51d5db9",
   "document_name": "test_pdf",
   "document_description": "test_pdf_description",

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -215,7 +215,7 @@ _target_languages = set(TARGET_LANGUAGES)
 
 
 def get_parser_output(
-        translated: bool, source_url: Union[str, None], languages: Sequence[str]
+    translated: bool, source_url: Union[str, None], languages: Sequence[str]
 ) -> ParserOutput:
     """Generate the parser output objects for the tests given input variables."""
     return ParserOutput(

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -83,6 +83,16 @@ def test_run_parser_local_series(test_input_dir) -> None:
         for output_file in Path(output_dir).glob("*.json"):
             assert ParserOutput.parse_file(output_file)
 
+            if "html" in str(output_file):
+                assert ParserOutput.parse_file(
+                    output_file).html_data.text_blocks != []
+
+            if "pdf" in str(output_file):
+                pdf_data = ParserOutput.parse_file(output_file).pdf_data
+                assert pdf_data.text_blocks != []
+                assert pdf_data.md5sum is not ""
+                assert pdf_data.page_metadata is not []
+
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 def test_run_parser_s3(test_input_dir) -> None:

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -54,9 +54,12 @@ def test_run_parser_local_parallel(test_input_dir) -> None:
 
             if "pdf" in str(output_file):
                 pdf_data = ParserOutput.parse_file(output_file).pdf_data
-                assert pdf_data.text_blocks != []
+                assert pdf_data.text_blocks != [] or pdf_data.text_blocks is not None
                 assert pdf_data.md5sum is not ""
-                assert pdf_data.page_metadata is not []
+                assert (
+                    pdf_data.page_metadata is not []
+                    or pdf_data.page_metadata is not None
+                )
 
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
@@ -89,9 +92,12 @@ def test_run_parser_local_series(test_input_dir) -> None:
 
             if "pdf" in str(output_file):
                 pdf_data = ParserOutput.parse_file(output_file).pdf_data
-                assert pdf_data.text_blocks != []
+                assert pdf_data.text_blocks != [] or pdf_data.text_blocks is not None
                 assert pdf_data.md5sum is not ""
-                assert pdf_data.page_metadata is not []
+                assert (
+                    pdf_data.page_metadata is not []
+                    or pdf_data.page_metadata is not None
+                )
 
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -49,6 +49,10 @@ def test_run_parser_local_parallel(test_input_dir) -> None:
         for output_file in Path(output_dir).glob("*.json"):
             assert ParserOutput.parse_file(output_file)
 
+            text_blocks = ParserOutput.parse_file(output_file).text_blocks
+            if "html" in str(output_file) or "pdf" in str(output_file):
+                assert text_blocks != None and text_blocks != []
+
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 def test_run_parser_local_series(test_input_dir) -> None:
@@ -73,6 +77,7 @@ def test_run_parser_local_series(test_input_dir) -> None:
 
         for output_file in Path(output_dir).glob("*.json"):
             assert ParserOutput.parse_file(output_file)
+
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 def test_run_parser_s3(test_input_dir) -> None:
@@ -205,7 +210,7 @@ _target_languages = set(TARGET_LANGUAGES)
 
 
 def get_parser_output(
-    translated: bool, source_url: Union[str, None], languages: Sequence[str]
+        translated: bool, source_url: Union[str, None], languages: Sequence[str]
 ) -> ParserOutput:
     """Generate the parser output objects for the tests given input variables."""
     return ParserOutput(

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -50,7 +50,8 @@ def test_run_parser_local_parallel(test_input_dir) -> None:
             assert ParserOutput.parse_file(output_file)
 
             if "html" in str(output_file):
-                assert ParserOutput.parse_file(output_file).html_data.text_blocks != []
+                html_data = ParserOutput.parse_file(output_file).html_data
+                assert html_data.text_blocks != [] or html_data.text_blocks is not None
 
             if "pdf" in str(output_file):
                 pdf_data = ParserOutput.parse_file(output_file).pdf_data
@@ -87,8 +88,8 @@ def test_run_parser_local_series(test_input_dir) -> None:
             assert ParserOutput.parse_file(output_file)
 
             if "html" in str(output_file):
-                assert ParserOutput.parse_file(
-                    output_file).html_data.text_blocks != []
+                html_data = ParserOutput.parse_file(output_file).html_data
+                assert html_data.text_blocks != [] or html_data.text_blocks is not None
 
             if "pdf" in str(output_file):
                 pdf_data = ParserOutput.parse_file(output_file).pdf_data

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -49,9 +49,14 @@ def test_run_parser_local_parallel(test_input_dir) -> None:
         for output_file in Path(output_dir).glob("*.json"):
             assert ParserOutput.parse_file(output_file)
 
-            text_blocks = ParserOutput.parse_file(output_file).text_blocks
-            if "html" in str(output_file) or "pdf" in str(output_file):
-                assert text_blocks != None and text_blocks != []
+            if "html" in str(output_file):
+                assert ParserOutput.parse_file(output_file).html_data.text_blocks != []
+
+            if "pdf" in str(output_file):
+                pdf_data = ParserOutput.parse_file(output_file).pdf_data
+                assert pdf_data.text_blocks != []
+                assert pdf_data.md5sum is not ""
+                assert pdf_data.page_metadata is not []
 
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -26,7 +26,7 @@ def test_input_dir() -> Path:
 
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
-def test_run_parser_local(test_input_dir) -> None:
+def test_run_parser_local_parallel(test_input_dir) -> None:
     """Test that the parsing CLI runs and outputs a file."""
     with tempfile.TemporaryDirectory() as output_dir:
         runner = CliRunner()
@@ -37,7 +37,8 @@ def test_run_parser_local(test_input_dir) -> None:
 
         assert result.exit_code == 0
 
-        # Default config is to translate to English, and the HTML doc is already in English - so we just expect a translation of the PDF
+        # Default config is to translate to English, and the HTML doc is already in
+        # English - so we just expect a translation of the PDF
         assert set(Path(output_dir).glob("*.json")) == {
             Path(output_dir) / "test_html.json",
             Path(output_dir) / "test_pdf.json",
@@ -48,6 +49,30 @@ def test_run_parser_local(test_input_dir) -> None:
         for output_file in Path(output_dir).glob("*.json"):
             assert ParserOutput.parse_file(output_file)
 
+
+@pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
+def test_run_parser_local_series(test_input_dir) -> None:
+    """Test that the parsing CLI runs and outputs a file."""
+    with tempfile.TemporaryDirectory() as output_dir:
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli_main, [str(test_input_dir), output_dir]
+        )
+
+        assert result.exit_code == 0
+
+        # Default config is to translate to English, and the HTML doc is already in
+        # English - so we just expect a translation of the PDF
+        assert set(Path(output_dir).glob("*.json")) == {
+            Path(output_dir) / "test_html.json",
+            Path(output_dir) / "test_pdf.json",
+            Path(output_dir) / "test_no_content_type.json",
+            Path(output_dir) / "test_pdf_translated_en.json",
+        }
+
+        for output_file in Path(output_dir).glob("*.json"):
+            assert ParserOutput.parse_file(output_file)
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 def test_run_parser_s3(test_input_dir) -> None:

--- a/cli/translate_outputs.py
+++ b/cli/translate_outputs.py
@@ -18,7 +18,8 @@ def should_be_translated(document: ParserOutput) -> bool:
     """
     Determine if a document should be translated.
 
-    If the document has not already been translated and has not null source url, then it should be translated.
+    If the document has not already been translated and has not null source url,
+    then it should be translated.
     """
     if document.translated or document.document_source_url is None:
         return False


### PR DESCRIPTION
### Fix Failing Tests 

**Test format:** 

- The parser is instantiated and parser input jsons passed into the parser with varying types e.g. pdf, html, other content-type etc. 
- The tests rely on real world infrastructure to provide pdf documents from s3 as well as the cdn domain. This allows pdf documents to be pulled down and converted. 
- The tests assert that the output jsons exist for each of the input jsons but don't check the content. 

**PR Changes:**

1. Update to actually test the pdf parser
Noticed this as the tests passed even when I was using dummy credentials for azure. 

As we can see from the below image we aren't actually even testing functionality of the pdf parser for this document as it fails to download from the cdn. Thus, this also needs to be updated. This is probably again due to the tests being written before the change where we hard enforced a download prefix from the cdn. [HERE](https://github.com/climatepolicyradar/navigator-document-parser/blob/main/cli/parse_pdfs.py#L124)

![image](https://github.com/climatepolicyradar/navigator-document-parser/assets/58440325/ba197d49-a478-450f-a822-2d8a763573c6)

The cdn path of the test document and the cdn domain in the makefile have been updated to facilitate correct download. 

2. Tests not asserting content of output jsons  

I'm assuming that since the tests were written we have implemented the copy to output feature that ensures we don't drop documents across the parser (e.g. every input document of parser input type is converted to parser output and saved to the output directory). 

Thus, the tests have been updated to assert that the content of the documents is correct to ensure we have actually extracted text. Also testing locally in series as well as parallel. 

3. Refactor 
Removed some unneeded references to layout parser etc. in the `makefile` and `.env.example`

4. Update to the workflow ci.yml to use env vars from the git repo. **_I can't personally add these due to perms._** 
