### PR TITLE
ParserOutput to IndexerInput validation error in Pipeline Integration Tests 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -278,8 +278,8 @@ requests = "^2.31.0"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/azure-pdf-parser.git"
-reference = "c567c996e940ae32da51dd834a44073dc973ed96"
-resolved_reference = "c567c996e940ae32da51dd834a44073dc973ed96"
+reference = "main-89edd6fe"
+resolved_reference = "89edd6fe3e559bf44d0d3384001d0503af94de7f"
 
 [[package]]
 name = "beautifulsoup4"
@@ -3532,4 +3532,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "f0b243ff81351bf11783905da583da07aae9df1d7fc5d2184edf8fc5de3a57db"
+content-hash = "faf79f433cdb1cc603b2cd69a93ff764a5b35017079e14c603574a229e9a6d1e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -270,7 +270,7 @@ develop = false
 
 [package.dependencies]
 azure-ai-formrecognizer = "^3.2.1"
-cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", rev = "29e3078316620f08fd0e2fde95cc450f819f0644"}
+cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", rev = "7413e66d446667d9213e1a2cc0b63ceba5d8bb09"}
 langdetect = "^1.0.9"
 pypdf = "^3.15.0"
 requests = "^2.31.0"
@@ -278,8 +278,8 @@ requests = "^2.31.0"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/azure-pdf-parser.git"
-reference = "73af699bbd52ddb57e5d12aa68640caed3e1fd76"
-resolved_reference = "73af699bbd52ddb57e5d12aa68640caed3e1fd76"
+reference = "c567c996e940ae32da51dd834a44073dc973ed96"
+resolved_reference = "c567c996e940ae32da51dd834a44073dc973ed96"
 
 [[package]]
 name = "beautifulsoup4"
@@ -723,8 +723,8 @@ tqdm = "^4.64.1"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/data-access.git"
-reference = "29e3078316620f08fd0e2fde95cc450f819f0644"
-resolved_reference = "29e3078316620f08fd0e2fde95cc450f819f0644"
+reference = "7413e66d446667d9213e1a2cc0b63ceba5d8bb09"
+resolved_reference = "7413e66d446667d9213e1a2cc0b63ceba5d8bb09"
 
 [[package]]
 name = "cryptography"
@@ -3532,4 +3532,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "ee0f6a43060a385a8f2089698a9ffdff8505a7f9f51bdff7fd115bd6067453e8"
+content-hash = "f0b243ff81351bf11783905da583da07aae9df1d7fc5d2184edf8fc5de3a57db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ azure-ai-formrecognizer = "^3.2.1"
 pytest = "^7.4.0"
 mock = "^5.1.0"
 pypdf2 = "^3.0.1"
-azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", rev = "73af699bbd52ddb57e5d12aa68640caed3e1fd76"}
+azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", rev = "c567c996e940ae32da51dd834a44073dc973ed96"}
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.20.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ azure-ai-formrecognizer = "^3.2.1"
 pytest = "^7.4.0"
 mock = "^5.1.0"
 pypdf2 = "^3.0.1"
-azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", rev = "c567c996e940ae32da51dd834a44073dc973ed96"}
+azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", rev = "main-89edd6fe"}
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.20.0"


### PR DESCRIPTION
### Bug Fix PR 

Full description of the problem at the linear ticket below, effectively a validation bug at the interface between the parser and the indexer:
[Linear Ticket](https://linear.app/climate-policy-radar/issue/RND-259/solve-new-parser-bug)

Updating to use an updated azure pdf parser that references a draft data access library.
- [Data Access Lib PR](https://github.com/climatepolicyradar/data-access/pull/30)
- [Azure PDF Parser PR](https://github.com/climatepolicyradar/azure-pdf-parser/pull/7)