### PR TITLE
Bumping the azure parser.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -278,8 +278,8 @@ requests = "^2.31.0"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/azure-pdf-parser.git"
-reference = "merge-92a9a4b1"
-resolved_reference = "92a9a4b19f82fbef67b64463e35deaa0eb5a30ac"
+reference = "main-117d98e6"
+resolved_reference = "117d98e6cc01c244f836fd5be3d753770fe9352c"
 
 [[package]]
 name = "beautifulsoup4"
@@ -3532,4 +3532,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "1f704b0114e198fd6af615d8612a43ac3a0f0def4e49742f34020a8bd3bf77fb"
+content-hash = "ddf06ac057c47911836748a3bd39eec671f7655823a2b515851d0ad1dd8b0aeb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -278,8 +278,8 @@ requests = "^2.31.0"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/azure-pdf-parser.git"
-reference = "main-89edd6fe"
-resolved_reference = "89edd6fe3e559bf44d0d3384001d0503af94de7f"
+reference = "merge-92a9a4b1"
+resolved_reference = "92a9a4b19f82fbef67b64463e35deaa0eb5a30ac"
 
 [[package]]
 name = "beautifulsoup4"
@@ -3532,4 +3532,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "faf79f433cdb1cc603b2cd69a93ff764a5b35017079e14c603574a229e9a6d1e"
+content-hash = "1f704b0114e198fd6af615d8612a43ac3a0f0def4e49742f34020a8bd3bf77fb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ azure-ai-formrecognizer = "^3.2.1"
 pytest = "^7.4.0"
 mock = "^5.1.0"
 pypdf2 = "^3.0.1"
-azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", rev = "main-89edd6fe"}
+azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", rev = "merge-92a9a4b1"}
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.20.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ azure-ai-formrecognizer = "^3.2.1"
 pytest = "^7.4.0"
 mock = "^5.1.0"
 pypdf2 = "^3.0.1"
-azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", rev = "merge-92a9a4b1"}
+azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", rev = "main-117d98e6"}
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.20.0"


### PR DESCRIPTION
### Bumping the azure parser: 
-  To a version that starts the page indexing from 0 not 1. 
- To a version that converts the dimensions of the bounding boxes and page dimensions to 70ppi. 

Raised during this comment:

https://github.com/climatepolicyradar/navigator-data-pipeline/pull/102#issuecomment-1678737414