### PR TITLE
Retry on failure with large document endpoint

### DIFF
--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union, Tuple, Sequence
 import hashlib
 
 import cloudpathlib.exceptions
@@ -20,10 +20,11 @@ from cpr_data_access.parser_models import (
     ParserOutput,
     PDFData,
 )
-from azure_pdf_parser import AzureApiWrapper, azure_api_response_to_parser_output, \
-    PDFPage
-from typing_extensions import Sequence
-
+from azure_pdf_parser import (
+    AzureApiWrapper,
+    azure_api_response_to_parser_output,
+    PDFPage,
+)
 from src.config import AZURE_PROCESSOR_KEY, AZURE_PROCESSOR_ENDPOINT
 
 CDN_DOMAIN = os.environ["CDN_DOMAIN"]
@@ -290,10 +291,10 @@ def parse_file(
                 },
             )
             try:
-                response_: Tuple[Sequence[PDFPage], AnalyzeResult] = (
-                    azure_client.analyze_large_document_from_bytes(
-                        doc_bytes=read_local_json_to_bytes(str(pdf_path)),
-                    )
+                response_: Tuple[
+                    Sequence[PDFPage], AnalyzeResult
+                ] = azure_client.analyze_large_document_from_bytes(
+                    doc_bytes=read_local_json_to_bytes(str(pdf_path)),
                 )
                 api_response: AnalyzeResult = response_[1]
             except Exception as e:

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -268,7 +268,7 @@ def parse_file(
                 doc_bytes=read_local_json_to_bytes(str(pdf_path)),
             )
         except ServiceRequestError as e:
-            _LOGGER.exception(
+            _LOGGER.error(
                 "Failed to parse document with Azure API. This is most likely due to "
                 "incorrect azure api credentials.",
                 extra={
@@ -280,7 +280,7 @@ def parse_file(
             )
             return None
         except HttpResponseError as e:
-            _LOGGER.exception(
+            _LOGGER.error(
                 "Failed to parse document with Azure API with default endpoint, "
                 "retrying with large document endpoint.",
                 extra={


### PR DESCRIPTION
### This PR: 
- Updates the pdf parsing functionality in the document parser that utilises the azure wrapper package to retry should the request fail due to a `HTTPError`.

The reason why I believe it is the `HTTPError` that should be caught is due to the following docstring on the method we use in the wrapper. Found here -> [code](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_generated/_operations_mixin.py#L117)

![image](https://github.com/climatepolicyradar/navigator-document-parser/assets/58440325/ff212ea9-586a-4b0c-ac9a-25c6e72a4fe6)
