### PR TITLE
Save Intermediate Api Response 

### DIFF
--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -267,6 +267,8 @@ def parse_file(
             api_response: AnalyzeResult = azure_client.analyze_document_from_bytes(
                 doc_bytes=read_local_json_to_bytes(str(pdf_path)),
             )
+
+            # TODO - save intermediate response to s3
         except ServiceRequestError as e:
             _LOGGER.error(
                 "Failed to parse document with Azure API. This is most likely due to "


### PR DESCRIPTION
### This Pull Request: 
- (TODO) Saves the raw Api Response from Azure to s3. 

**Requirements:**
- Save json to local or s3.
- Failure to save will not stop the python program.
- Intermediate save config will be provided to the cli. 
     - We will have a default save prefix at `bucket/azure-api-response-cache`. 
     - Saving intermediate results will default to `false`. 
- The save file path will be  `bucket/azure-api-response-cache/{document_import_id}/{timestamp}.json`.
     - The use of a time stamp rather than the import id for the file name is in case we reprocess the document after a change to a source url for example. Thus, we wouldn't want to overwrite an existing document. 
