### PR TITLE
Save api responses as an array of json objects 

### DIFF
--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -247,7 +247,7 @@ def add_parser_metadata(
 def save_api_response(
     azure_cache_dir: Union[Path, S3Path, None],
     input_task: ParserInput,
-    api_response_array: [AnalyzeResult]
+    api_response_array: [AnalyzeResult],
 ) -> None:
     """Cache the raw api responses as an array of json data."""
     if azure_cache_dir:
@@ -255,16 +255,13 @@ def save_api_response(
             document_azure_cache_dir = azure_cache_dir / input_task.document_id
             document_azure_cache_dir.mkdir(parents=True, exist_ok=True)
             document_azure_cache_path = (
-                    document_azure_cache_dir / f"{time.time_ns()}.json"
+                document_azure_cache_dir / f"{time.time_ns()}.json"
             )
             if not document_azure_cache_path.exists():
                 document_azure_cache_path.touch()
             document_azure_cache_path.write_text(
                 json.dumps(
-                    [
-                        api_response.to_dict()
-                        for api_response in api_response_array
-                    ]
+                    [api_response.to_dict() for api_response in api_response_array]
                 )
             )
             _LOGGER.info(
@@ -361,7 +358,7 @@ def parse_file(
             save_api_response(
                 azure_cache_dir=azure_cache_dir,
                 input_task=input_task,
-                api_response_array=[api_response]
+                api_response_array=[api_response],
             )
         except ServiceRequestError as e:
             _LOGGER.error(
@@ -387,10 +384,11 @@ def parse_file(
                 },
             )
             try:
-                batch_responses_array, api_response = (
-                    azure_client.analyze_large_document_from_bytes(
-                        doc_bytes=read_local_json_to_bytes(str(pdf_path)),
-                    )
+                (
+                    batch_responses_array,
+                    api_response,
+                ) = azure_client.analyze_large_document_from_bytes(
+                    doc_bytes=read_local_json_to_bytes(str(pdf_path)),
                 )
                 save_api_response(
                     azure_cache_dir=azure_cache_dir,
@@ -398,7 +396,7 @@ def parse_file(
                     api_response_array=[
                         api_response_.extracted_content
                         for api_response_ in batch_responses_array
-                    ]
+                    ],
                 )
             except Exception as e:
                 _LOGGER.exception(

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -244,6 +244,50 @@ def add_parser_metadata(
     return parser_output
 
 
+def save_api_response(
+    azure_cache_dir: Union[Path, S3Path, None],
+    input_task: ParserInput,
+    api_response_array: [AnalyzeResult]
+) -> None:
+    """Cache the raw api responses as an array of json data."""
+    if azure_cache_dir:
+        try:
+            document_azure_cache_dir = azure_cache_dir / input_task.document_id
+            document_azure_cache_dir.mkdir(parents=True, exist_ok=True)
+            document_azure_cache_path = (
+                    document_azure_cache_dir / f"{time.time_ns()}.json"
+            )
+            if not document_azure_cache_path.exists():
+                document_azure_cache_path.touch()
+            document_azure_cache_path.write_text(
+                json.dumps(
+                    [
+                        api_response.to_dict()
+                        for api_response in api_response_array
+                    ]
+                )
+            )
+            _LOGGER.info(
+                "Saved raw azure api response.",
+                extra={
+                    "props": {
+                        "document_id": input_task.document_id,
+                        "azure_cache_path": str(document_azure_cache_path),
+                    }
+                },
+            )
+        except Exception as e:
+            _LOGGER.exception(
+                "Failed to save the raw azure api response.",
+                extra={
+                    "props": {
+                        "document_id": input_task.document_id,
+                        "error_message": str(e),
+                    }
+                },
+            )
+
+
 def parse_file(
     input_task: ParserInput,
     azure_client: AzureApiWrapper,
@@ -314,37 +358,11 @@ def parse_file(
             api_response: AnalyzeResult = azure_client.analyze_document_from_bytes(
                 doc_bytes=read_local_json_to_bytes(str(pdf_path)),
             )
-            try:
-                if azure_cache_dir:
-                    document_azure_cache_dir = azure_cache_dir / input_task.document_id
-                    document_azure_cache_dir.mkdir(parents=True, exist_ok=True)
-                    document_azure_cache_path = (
-                        document_azure_cache_dir / f"{time.time_ns()}.json"
-                    )
-                    if not document_azure_cache_path.exists():
-                        document_azure_cache_path.touch()
-                    document_azure_cache_path.write_text(
-                        json.dumps(api_response.to_dict())
-                    )
-                    _LOGGER.info(
-                        "Saved raw azure api response.",
-                        extra={
-                            "props": {
-                                "document_id": input_task.document_id,
-                                "azure_cache_path": str(document_azure_cache_path),
-                            }
-                        },
-                    )
-            except Exception as e:
-                _LOGGER.exception(
-                    "Failed to save the raw azure api response.",
-                    extra={
-                        "props": {
-                            "document_id": input_task.document_id,
-                            "error_message": str(e),
-                        }
-                    },
-                )
+            save_api_response(
+                azure_cache_dir=azure_cache_dir,
+                input_task=input_task,
+                api_response_array=[api_response]
+            )
         except ServiceRequestError as e:
             _LOGGER.error(
                 "Failed to parse document with Azure API. This is most likely due to "
@@ -369,12 +387,19 @@ def parse_file(
                 },
             )
             try:
-                response_: Tuple[
-                    Sequence[PDFPage], AnalyzeResult
-                ] = azure_client.analyze_large_document_from_bytes(
-                    doc_bytes=read_local_json_to_bytes(str(pdf_path)),
+                batch_responses_array, api_response = (
+                    azure_client.analyze_large_document_from_bytes(
+                        doc_bytes=read_local_json_to_bytes(str(pdf_path)),
+                    )
                 )
-                api_response: AnalyzeResult = response_[1]
+                save_api_response(
+                    azure_cache_dir=azure_cache_dir,
+                    input_task=input_task,
+                    api_response_array=[
+                        api_response_.extracted_content
+                        for api_response_ in batch_responses_array
+                    ]
+                )
             except Exception as e:
                 _LOGGER.exception(
                     "Failed to parse document with Azure API using the large document "

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -25,7 +25,6 @@ from cpr_data_access.parser_models import (
 from azure_pdf_parser import (
     AzureApiWrapper,
     azure_api_response_to_parser_output,
-    PDFPage,
 )
 
 from src.base import PARSER_METADATA_KEY

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import List, Optional, Union, Tuple, Sequence
+from typing import List, Optional, Union
 import hashlib
 import json
 from datetime import datetime

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -260,7 +260,12 @@ def save_api_response(
                 document_azure_cache_path.touch()
             document_azure_cache_path.write_text(
                 json.dumps(
-                    [api_response.to_dict() for api_response in api_response_array]
+                    {
+                        input_task.document_id: [
+                            api_response.to_dict()
+                            for api_response in api_response_array
+                        ]
+                    }
                 )
             )
             _LOGGER.info(

--- a/cli/test/conftest.py
+++ b/cli/test/conftest.py
@@ -58,8 +58,14 @@ def test_input_dir() -> Path:
 
 
 @pytest.fixture()
-def test_azure_api_response_dir() -> Path:
-    return (Path(__file__).parent / "test_data" / "azure_api_response_cache").resolve()
+def azure_api_cache_dir() -> str:
+    """The directory where the azure api response cache is stored."""
+    return "azure_api_response_cache"
+
+
+@pytest.fixture()
+def test_azure_api_response_dir(azure_api_cache_dir) -> Path:
+    return (Path(__file__).parent / "test_data" / azure_api_cache_dir).resolve()
 
 
 @pytest.fixture()

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -159,8 +159,7 @@ def test_run_parser_cache_azure_response_local(
 
             [
                 AnalyzeResult.from_dict(response)
-                for response in
-                json.loads(file.read_text())
+                for response in json.loads(file.read_text())
             ]
             assert re.match(archived_file_name_pattern, file.name)
 
@@ -610,9 +609,7 @@ def test_fail_safely_on_azure_http_response_error(
                     assert parser_output.pdf_data.md5sum != ""
                     assert parser_output.pdf_data.page_metadata not in [[], None]
 
-            azure_responses = set(
-                Path(test_azure_api_response_dir).glob("*/*.json")
-            )
+            azure_responses = set(Path(test_azure_api_response_dir).glob("*/*.json"))
             assert len(azure_responses) == 1
             for file in azure_responses:
                 assert re.match(archived_file_name_pattern, file.name)

--- a/cli/test/test_run_parser.py
+++ b/cli/test/test_run_parser.py
@@ -156,11 +156,13 @@ def test_run_parser_cache_azure_response_local(
         for file in azure_responses:
             # Check that the object is of the correct structure and has the correct
             # file name
+            azure_response = json.loads(file.read_text())
+            assert len(azure_response.keys()) == 1
+            assert len(azure_response.values()) == 1
 
-            [
-                AnalyzeResult.from_dict(response)
-                for response in json.loads(file.read_text())
-            ]
+            azure_response_array = list(azure_response.values())[0]
+            assert isinstance(azure_response_array, list)
+            [AnalyzeResult.from_dict(response) for response in azure_response_array]
             assert re.match(archived_file_name_pattern, file.name)
 
 
@@ -208,10 +210,13 @@ def test_run_parser_cache_azure_response_s3(
         for file in azure_responses:
             # Check that the object is of the correct structure and has the correct
             # file name
-            [
-                AnalyzeResult.from_dict(response)
-                for response in json.loads(file.read_text())
-            ]
+            azure_response = json.loads(file.read_text())
+            assert len(azure_response.keys()) == 1
+            assert len(azure_response.values()) == 1
+
+            azure_response_array = list(azure_response.values())[0]
+            assert isinstance(azure_response_array, list)
+            [AnalyzeResult.from_dict(response) for response in azure_response_array]
             assert re.match(archived_file_name_pattern, file.name)
             assert file.parts[-2] == json.loads(pdf_file_data)["document_id"]
             assert file.parts[-3] == azure_api_cache_dir
@@ -616,10 +621,11 @@ def test_fail_safely_on_azure_http_response_error(
 
                 # Check that the object is of the correct structure and has the correct
                 # file name
-                analyse_result_array = json.loads(file.read_text())
-                assert isinstance(analyse_result_array, list)
-                [
-                    AnalyzeResult.from_dict(analyse_result)
-                    for analyse_result in analyse_result_array
-                ]
+                analyse_result = json.loads(file.read_text())
+                assert len(analyse_result.keys()) == 1
+                assert len(analyse_result.values()) == 1
+
+                azure_response_array = list(analyse_result.values())[0]
+                assert isinstance(azure_response_array, list)
+                [AnalyzeResult.from_dict(result) for result in azure_response_array]
                 assert file.parts[-3] == azure_api_cache_dir

--- a/poetry.lock
+++ b/poetry.lock
@@ -270,7 +270,7 @@ develop = false
 
 [package.dependencies]
 azure-ai-formrecognizer = "^3.2.1"
-cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag = "v0.1.4"}
+cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag = "v0.1.8"}
 langdetect = "^1.0.9"
 pypdf = "^3.15.0"
 requests = "^2.31.0"
@@ -278,8 +278,8 @@ requests = "^2.31.0"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/azure-pdf-parser.git"
-reference = "v0.1.5"
-resolved_reference = "bd0070263d636c80d7bb9dd343b523eb8f578523"
+reference = "v0.1.6"
+resolved_reference = "a0a4d3022a8bd3f5c603d8e86bc2bd1dc70d67f6"
 
 [[package]]
 name = "beautifulsoup4"
@@ -666,7 +666,7 @@ files = [
 
 [[package]]
 name = "cpr-data-access"
-version = "0.1.0"
+version = "0.1.8"
 description = ""
 optional = false
 python-versions = "^3.9"
@@ -686,8 +686,8 @@ tqdm = "^4.64.1"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/data-access.git"
-reference = "v0.1.4"
-resolved_reference = "514f332c6aa55e43316036e9406c2b39bab37375"
+reference = "v0.1.8"
+resolved_reference = "896497058b6d84b6dcebedf384aa78b607f7c66d"
 
 [[package]]
 name = "cryptography"
@@ -3623,4 +3623,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "0974def5d0636dcb46733747ff300b476f20d9a9156222f015bf60b12ea9c2b6"
+content-hash = "d5ee7173c0c4780e93566dda453ec7c15ff705edbd44b31b6c5284b525c37a63"

--- a/poetry.lock
+++ b/poetry.lock
@@ -278,8 +278,8 @@ requests = "^2.31.0"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/azure-pdf-parser.git"
-reference = "v0.1.4"
-resolved_reference = "4529522386475f98518a752cd329e262ead0db08"
+reference = "v0.1.5"
+resolved_reference = "bd0070263d636c80d7bb9dd343b523eb8f578523"
 
 [[package]]
 name = "beautifulsoup4"
@@ -3623,4 +3623,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "4be819a3156cbeb673485562a9472da0192a0d86c7be9a68804cee4010cf7cf4"
+content-hash = "0974def5d0636dcb46733747ff300b476f20d9a9156222f015bf60b12ea9c2b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ azure-ai-formrecognizer = "^3.2.1"
 pytest = "^7.4.0"
 mock = "^5.1.0"
 pypdf2 = "^3.0.1"
-azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", tag = "v0.1.4"}
+azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", tag = "v0.1.5"}
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.20.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ azure-ai-formrecognizer = "^3.2.1"
 pytest = "^7.4.0"
 mock = "^5.1.0"
 pypdf2 = "^3.0.1"
-azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", tag = "v0.1.5"}
+azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", tag = "v0.1.6"}
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.20.0"


### PR DESCRIPTION
### Save Api Responses as an Array
---
Previously we were saving api responses from azure as just one response. 

I thought we were saving large documents as the merged api response but looking at the code I don't think we actually were. 

Therefore, this PR is an initial draft at saving as an array of api responses.

This is so we can recover from a position of needing to recreate parser output objects again should the schema change etc. without spending more money on the api. 