### PR TITLE
reformat the package inclusion to give users the actual src directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,10 @@ name = "navigator-document-parser"
 version = "0.1.0"
 description = "Parsing PDFs and websites containing laws and policies"
 authors = ["CPR Tech <tech@climatepolicyradar.org>"]
-packages = [{ include = "src", from = "." }]
+packages = [
+  { include = "**/*.py", from = "src", to = "navigator_document_parser" },
+]
+
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -18,19 +21,19 @@ playwright = "^1.35.0"
 readability-lxml = "^0.8.1"
 bleach = "^5.0.1"
 python-json-logger = "^2.0.4"
-cloudpathlib = {extras = ["s3"], version = "^0.10.0"}
+cloudpathlib = { extras = ["s3"], version = "^0.10.0" }
 PyMuPDF = "^1.20.2"
 google-cloud-translate = "^3.8.2"
 psutil = "^5.9.2"
 multiprocessing-logging = "^0.3.3"
 json-logging = "^1.3.0"
 tenacity = "^8.2.1"
-pillow = "<10"  # to fix import of Image.LINEAR by dependency
+pillow = "<10"                                                                                            # to fix import of Image.LINEAR by dependency
 azure-ai-formrecognizer = "^3.2.1"
 pytest = "^7.4.0"
 mock = "^5.1.0"
 pypdf2 = "^3.0.1"
-azure-pdf-parser = {git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", tag = "v0.3.1"}
+azure-pdf-parser = { git = "https://github.com/climatepolicyradar/azure-pdf-parser.git", tag = "v0.3.1" }
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.20.0"


### PR DESCRIPTION
The previous PR included a `packages` section of the `pyproject.toml` which was incorrectly formatted.

Restructing this allows users to run eg 

```py
from navigator_document_parser.translator.translate import translate_parser_output
```

when `navigator_document_parser` is installed in their project