### PR TITLE
fix: Make Dependabot package ecosystems unique

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     ignore:
       - dependency-name: cpr_sdk
     reviewers:
-      - "climatepolicyradar/deng"
+      - climatepolicyradar/deng
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -15,7 +15,7 @@ updates:
     ignore:
       - dependency-name: cpr_sdk
     reviewers:
-      - "climatepolicyradar/deng"
+      - climatepolicyradar/deng
   - package-ecosystem: pip
     directory: /
     schedule:
@@ -23,4 +23,5 @@ updates:
     allow:
       - dependency-name: cpr_sdk
     reviewers:
-      - "climatepolicyradar/deng"
+      - climatepolicyradar/deng
+    target-branch: main


### PR DESCRIPTION
After merging #125, there's been an invalid Dependabot config warning [1][2] on `main`. We had a similar issue on another repository last week. This uses the same fix.

[1] `Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'pip' has overlapping directories.`
[2] https://github.com/climatepolicyradar/navigator-document-parser/runs/27553758790