### PR TITLE
fix: Use regex-kind string

### DIFF
--- a/cli/test/conftest.py
+++ b/cli/test/conftest.py
@@ -71,7 +71,7 @@ def test_azure_api_response_dir(azure_api_cache_dir) -> Path:
 
 @pytest.fixture()
 def archived_file_name_pattern() -> str:
-    return "^\d+\.json$"  # noqa: W605
+    return r"^\d+\.json$"
 
 
 @pytest.fixture()


### PR DESCRIPTION
This fixes this warning, that's being seen when running tests.

```
cli/test/conftest.py:74
  /Users/jesse/src/github.com/climatepolicyradar/navigator-document-parser/cli/test/conftest.py:74: SyntaxWarning: invalid escape sequence '\d'
    return "^\d+\.json$"  # noqa: W605
```