### PR TITLE
to decide whether to run PDF parser, check for PDF file in CDN

### DIFF
--- a/cli/run_parser.py
+++ b/cli/run_parser.py
@@ -12,7 +12,6 @@ from cloudpathlib import S3Path, CloudPath
 from cpr_sdk.parser_models import (
     ParserInput,
     CONTENT_TYPE_HTML,
-    CONTENT_TYPE_PDF,
 )
 
 sys.path.append("..")
@@ -216,10 +215,14 @@ def main(
     output_tasks_paths = []
     for task in tasks:
         output_tasks_paths.append(output_dir_as_path / f"{task.document_id}.json")
-        if task.document_content_type == CONTENT_TYPE_HTML:
-            html_tasks.append(task)
-        elif task.document_content_type == CONTENT_TYPE_PDF:
+        if (
+            task.document_cdn_object is not None
+            and task.document_cdn_object.lower().endswith(".pdf")
+        ):
             pdf_tasks.append(task)
+        elif task.document_content_type == CONTENT_TYPE_HTML:
+            # This code path should never be hit as we convert all HTML to PDF
+            html_tasks.append(task)
         else:
             no_processing_tasks.append(task)
 

--- a/cli/run_parser.py
+++ b/cli/run_parser.py
@@ -232,7 +232,7 @@ def main(
             "props": {
                 "total_tasks": len(tasks),
                 "no_supported _content-type_tasks": len(no_processing_tasks),
-                "html_asks": len(html_tasks),
+                "html_tasks": len(html_tasks),
                 "pdf_tasks": len(pdf_tasks),
             }
         },


### PR DESCRIPTION
This means that HTML and docx files that we convert to PDFs are parsed by the PDF parser. Leaves in the code path to the HTML parser for now, in case it's ever useful for experiments or we decide to revisit it.

See [related ADR](https://github.com/climatepolicyradar/architecture-hub/pull/17)