### PR TITLE
Feature/pla 931 refactor parser stage remove env var files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,11 +25,8 @@ TARGET_LANGUAGES=en
 # Log Level e.g. INFO
 #LOGGING_LEVEL=
 
-# Files to parse by env e.g. $1331.0.json ($ delimiter)
-#FILES_TO_PARSE=
-
-# Files to parse by flag e.g. 1331.0.json
-#FILES_TO_PARSE_FLAG=
+# Document Import Ids to parse e.g. "CCLW.exec.1.1,UNFCC.document.2.2,..."
+#DOCUMENT_IMPORT_IDS=
 
 # Azure Processor Credentials
 #AZURE_PROCESSOR_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
-        run:  |
+        run: |
           cp .env.example .env
           make build
 
@@ -27,6 +27,7 @@ jobs:
         env:
           AZURE_PROCESSOR_KEY: ${{ secrets.AZURE_PROCESSOR_KEY }}
           AZURE_PROCESSOR_ENDPOINT: ${{ secrets.AZURE_PROCESSOR_ENDPOINT }}
+          CDN_DOMAIN: ${{ secrets.CDN_DOMAIN }}
 
       - name: Run Integration Tests
         run: echo TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         env:
           AZURE_PROCESSOR_KEY: ${{ secrets.AZURE_PROCESSOR_KEY }}
           AZURE_PROCESSOR_ENDPOINT: ${{ secrets.AZURE_PROCESSOR_ENDPOINT }}
-          CDN_DOMAIN: ${{ secrets.CDN_DOMAIN }}
 
       - name: Run Integration Tests
         run: echo TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ COPY ./.pre-commit-config.yaml ./.flake8 ./.gitignore ./
 ENV PYTHONPATH "${PYTHONPATH}:/app"
 
 # Run the parser on the input s3 directory
-CMD [ "sh", "./cli/run.sh" ]
+ENTRYPOINT ["python3", "-m", "cli.run_parser"]

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ install:
 	poetry install
 
 run_local:
-	TARGET_LANGUAGES=en CDN_DOMAIN="${CDN_DOMAIN}" GOOGLE_APPLICATION_CREDENTIALS=./credentials/google-creds.json python -m cli.run_parser ./data/raw ./data/processed --document_import_ids "${DOCUMENT_IMPORT_IDS}"
+	TARGET_LANGUAGES=en GOOGLE_APPLICATION_CREDENTIALS=./credentials/google-creds.json python -m cli.run_parser ./data/raw ./data/processed --document_import_ids "${DOCUMENT_IMPORT_IDS}"
 
 test_local:
-	TARGET_LANGUAGES=en CDN_DOMAIN="${CDN_DOMAIN}" poetry run python -m pytest -vvv
+	TARGET_LANGUAGES=en poetry run python -m pytest -vvv
 
 build:
 	docker build -t navigator-document-parser .
@@ -23,12 +23,12 @@ pre-commit-checks-all-files:
 
 test:
 	docker build -t navigator-document-parser .
-	docker run -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e CDN_DOMAIN="${CDN_DOMAIN}" --network host --entrypoint python3 navigator-document-parser -m pytest -vvv
+	docker run -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" --network host --entrypoint python3 navigator-document-parser -m pytest -vvv
 
 run_docker:
 	docker build -t navigator-document-parser .
-	docker run --network host -v ${PWD}/data:/app/data -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e CDN_DOMAIN="${CDN_DOMAIN}" -e GOOGLE_CREDS="${GOOGLE_CREDS}" navigator-document-parser ./data/raw ./data/processed "${DOCUMENT_IMPORT_IDS}"
+	docker run --network host -v ${PWD}/data:/app/data -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e GOOGLE_CREDS="${GOOGLE_CREDS}" navigator-document-parser ./data/raw ./data/processed "${DOCUMENT_IMPORT_IDS}"
 
 run_local_against_s3:
 	docker build -t navigator-document-parser .
-	docker run -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e CDN_DOMAIN="${CDN_DOMAIN}" -e GOOGLE_CREDS="${GOOGLE_CREDS}" -it navigator-document-parser "${PARSER_INPUT_PREFIX}" "${PARSER_OUTPUT_PREFIX}" "${DOCUMENT_IMPORT_IDS}"
+	docker run -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e GOOGLE_CREDS="${GOOGLE_CREDS}" -it navigator-document-parser "${PARSER_INPUT_PREFIX}" "${PARSER_OUTPUT_PREFIX}" "${DOCUMENT_IMPORT_IDS}"

--- a/Makefile
+++ b/Makefile
@@ -9,34 +9,26 @@ install:
 	poetry install
 
 run_local:
-	TARGET_LANGUAGES=en CDN_DOMAIN=cdn.climatepolicyradar.org GOOGLE_APPLICATION_CREDENTIALS=./credentials/google-creds.json python -m cli.run_parser ./data/raw ./data/processed
+	TARGET_LANGUAGES=en CDN_DOMAIN="${CDN_DOMAIN}" GOOGLE_APPLICATION_CREDENTIALS=./credentials/google-creds.json python -m cli.run_parser ./data/raw ./data/processed --document_import_ids "${DOCUMENT_IMPORT_IDS}"
 
 test_local:
-	TARGET_LANGUAGES=en CDN_DOMAIN=cdn.climatepolicyradar.org poetry run python -m pytest -vvv
+	TARGET_LANGUAGES=en CDN_DOMAIN="${CDN_DOMAIN}" poetry run python -m pytest -vvv
 
 build:
 	docker build -t navigator-document-parser .
 	docker tag navigator-document-parser navigator-document-parser-staging
 
 pre-commit-checks-all-files:
-	docker run navigator-document-parser pre-commit run --all-files
+	docker run --entrypoint pre-commit navigator-document-parser run --all-files
 
 test:
 	docker build -t navigator-document-parser .
-	docker run -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e "CDN_DOMAIN=cdn.dev.climatepolicyradar.org" --network host navigator-document-parser python -m pytest -vvv
+	docker run -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e CDN_DOMAIN="${CDN_DOMAIN}" --network host --entrypoint python3 navigator-document-parser -m pytest -vvv
 
 run_docker:
 	docker build -t navigator-document-parser .
-	docker run --network host -v ${PWD}/data:/app/data navigator-document-parser python -m cli.run_parser ./data/raw ./data/processed
-
-run_on_specific_files_flag:
-	docker build -t html-parser .
-	docker run -it -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" navigator-document-parser python -m cli.run_parser "${PARSER_INPUT_PREFIX}" "${EMBEDDINGS_INPUT_PREFIX}" --s3 --files "${FILES_TO_PARSE_FLAG}"
-
-run_on_specific_files_env:
-	docker build -t html-parser .
-	docker run -it -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" -e files_to_parse="${FILES_TO_PARSE}" navigator-document-parser python -m cli.run_parser "${PARSER_INPUT_PREFIX}" "${EMBEDDINGS_INPUT_PREFIX}" --s3
+	docker run --network host -v ${PWD}/data:/app/data -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e CDN_DOMAIN="${CDN_DOMAIN}" -e GOOGLE_CREDS="${GOOGLE_CREDS}" navigator-document-parser ./data/raw ./data/processed "${DOCUMENT_IMPORT_IDS}"
 
 run_local_against_s3:
 	docker build -t navigator-document-parser .
-	docker run -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" -e CDN_DOMAIN="${CDN_DOMAIN}" -e GOOGLE_CREDS="${GOOGLE_CREDS}" -e PARSER_INPUT_PREFIX="${PARSER_INPUT_PREFIX}" -e EMBEDDINGS_INPUT_PREFIX="${EMBEDDINGS_INPUT_PREFIX}" -it navigator-document-parser
+	docker run -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" -e AZURE_PROCESSOR_KEY="${AZURE_PROCESSOR_KEY}" -e AZURE_PROCESSOR_ENDPOINT="${AZURE_PROCESSOR_ENDPOINT}" -e CDN_DOMAIN="${CDN_DOMAIN}" -e GOOGLE_CREDS="${GOOGLE_CREDS}" -it navigator-document-parser "${PARSER_INPUT_PREFIX}" "${PARSER_OUTPUT_PREFIX}" "${DOCUMENT_IMPORT_IDS}"

--- a/cli/parse_pdfs.py
+++ b/cli/parse_pdfs.py
@@ -28,9 +28,8 @@ from azure_pdf_parser import (
 )
 
 from src.base import PARSER_METADATA_KEY
-from src.config import AZURE_PROCESSOR_KEY, AZURE_PROCESSOR_ENDPOINT
+from src.config import AZURE_PROCESSOR_KEY, AZURE_PROCESSOR_ENDPOINT, CDN_DOMAIN
 
-CDN_DOMAIN = os.environ["CDN_DOMAIN"]
 DOCUMENT_BUCKET_PREFIX = os.getenv("DOCUMENT_BUCKET_PREFIX", "navigator")
 
 _LOGGER = logging.getLogger(__name__)

--- a/cli/run.sh
+++ b/cli/run.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-
-mkdir /app/credentials/
-echo "${GOOGLE_CREDS}" | base64 -d > /app/credentials/google-creds.json
-export GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/google-creds.json
-python3 -m cli.run_parser --s3 "${PARSER_INPUT_PREFIX}" "${EMBEDDINGS_INPUT_PREFIX}" --azure_api_response_cache_dir "s3://${PIPELINE_BUCKET}/${AZURE_API_RESPONSE_CACHE_DIR}"

--- a/cli/test/conftest.py
+++ b/cli/test/conftest.py
@@ -1,8 +1,8 @@
 import json
 from pathlib import Path
 from typing import Union
-import pytest
 
+import pytest
 from azure.ai.formrecognizer import AnalyzeResult
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,6 @@ TARGET_LANGUAGES: List[str] = (
 
 # Default set by trial and error based on behaviour of the parsing model
 PDF_N_PROCESSES = int(os.getenv("PDF_N_PROCESSES", multiprocessing.cpu_count() / 2))
-FILES_TO_PARSE = os.getenv("files_to_parse")
 LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "DEBUG").upper()
 
 AZURE_PROCESSOR_KEY = os.environ.get("AZURE_PROCESSOR_KEY")

--- a/src/config.py
+++ b/src/config.py
@@ -20,3 +20,5 @@ LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "DEBUG").upper()
 
 AZURE_PROCESSOR_KEY = os.environ.get("AZURE_PROCESSOR_KEY")
 AZURE_PROCESSOR_ENDPOINT = os.environ.get("AZURE_PROCESSOR_ENDPOINT")
+
+CDN_DOMAIN = os.getenv("CDN_DOMAIN", "cdn.dev.climatepolicyradar.org")


### PR DESCRIPTION
### Simplify Files to Run On 
- On main we currently provide two methods of providing files to run on. 
- An environment variable named `FILES_TO_PARSE` and a cli param called `--files`. 
- This pull request simplifies this by removing the environment variable and making document import ids an argument not an option. 
- We also remove the `run.sh` bash script in favour of running the python cli within the Docker image instead. 
- We also normalise the commands in the makefile such that they are consistent as well as removing hard coded cdn domains. 
- Apologies for no nice commits to step through, the commits from the stacked PR persisted here and I ended up shrinking the changes to one commit. 